### PR TITLE
fix(Employee): move Expected Daily Working Time to child table (DRC-148)

### DIFF
--- a/time_capture/custom_fields.py
+++ b/time_capture/custom_fields.py
@@ -32,12 +32,12 @@ def get_custom_fields():
 		],
 		"Employee": [
 			{
-				"fieldname": "expected_daily_working_hours",
-				"fieldtype": "Float",
+				"fieldname": "expected_working_hours",
+				"fieldtype": "Table",
 				"insert_after": "attendance_device_id",
-				"label": _("Expected Daily Working Hours"),
-				"translatable": 0,
+				"label": _("Expected Working Hours"),
 				"reqd": 1,
+				"options": "Employee Expected Working Hours",
 			},
 		],
 		"Task": [

--- a/time_capture/hooks.py
+++ b/time_capture/hooks.py
@@ -143,6 +143,9 @@ doc_events = {
 		"on_submit": "time_capture.scripts.attendance.on_submit",
 		"on_cancel": "time_capture.scripts.attendance.on_cancel",
 	},
+	"Employee": {
+		"before_validate": "time_capture.scripts.employee.before_validate",
+	},
 }
 
 # Scheduled Tasks

--- a/time_capture/patches.txt
+++ b/time_capture/patches.txt
@@ -3,4 +3,5 @@
 # Read docs to understand patches: https://frappeframework.com/docs/v14/user/en/database-migrations
 
 [post_model_sync]
-execute:from time_capture.install import after_install;after_install() # 2025-03-19 #2
+execute:from time_capture.install import after_install;after_install() # 2025-05-14 #15:26
+time_capture.patches.move_expected_working_time_to_child_table

--- a/time_capture/patches.txt
+++ b/time_capture/patches.txt
@@ -3,5 +3,6 @@
 # Read docs to understand patches: https://frappeframework.com/docs/v14/user/en/database-migrations
 
 [post_model_sync]
-execute:from time_capture.install import after_install;after_install() # 2025-05-14 #15:26
+execute:from time_capture.install import make_custom_fields;make_custom_fields() # 2025-07-01 #14:26
+execute:from time_capture.install import make_property_setters;make_property_setters() # 2025-07-01 #14:26
 time_capture.patches.move_expected_working_time_to_child_table

--- a/time_capture/patches/move_expected_working_time_to_child_table.py
+++ b/time_capture/patches/move_expected_working_time_to_child_table.py
@@ -2,12 +2,17 @@ import frappe
 
 
 def execute():
-	if not frappe.db.exists(
-		"Custom Field", {"dt": "Employee", "fieldname": "expected_daily_working_hours", "fieldtype": "Float"}
-	):
+	custom_field_filters = {
+		"dt": "Employee",
+		"fieldname": "expected_daily_working_hours",
+		"fieldtype": "Float",
+	}
+	if not frappe.db.exists("Custom Field", custom_field_filters):
 		return
 
-	for employee_id in frappe.get_all("Employee", filters={"expected_daily_working_hours": ("is", "set")}, pluck="name")::
+	for employee_id in frappe.get_all(
+		"Employee", filters={"expected_daily_working_hours": ("is", "set")}, pluck="name"
+	):
 		print(f"Updating {employee_id}")
 
 		employee = frappe.get_doc("Employee", employee_id)
@@ -22,6 +27,4 @@ def execute():
 			},
 		)
 		employee.save()
-	frappe.db.delete(
-		"Custom Field", {"dt": "Employee", "fieldname": "expected_daily_working_hours", "fieldtype": "Float"}
-	)
+	frappe.db.delete("Custom Field", custom_field_filters)

--- a/time_capture/patches/move_expected_working_time_to_child_table.py
+++ b/time_capture/patches/move_expected_working_time_to_child_table.py
@@ -1,0 +1,22 @@
+import frappe
+
+
+def execute():
+	if not frappe.db.exists(
+		"Custom Field", {"dt": "Employee", "fieldname": "expected_daily_working_hours", "fieldtype": "Float"}
+	):
+		return
+	for e in frappe.db.get_all("Employee", filters={"expected_daily_working_hours": ["is", "set"]}):
+		print(f"Updating {e.name}")
+		employee = frappe.get_doc("Employee", e.name)
+		employee.append(
+			"expected_working_hours",
+			{
+				"valid_from": employee.date_of_joining,
+				"expected_daily_working_hours": employee.expected_daily_working_hours,
+			},
+		)
+		employee.save()
+	frappe.db.delete(
+		"Custom Field", {"dt": "Employee", "fieldname": "expected_daily_working_hours", "fieldtype": "Float"}
+	)

--- a/time_capture/patches/move_expected_working_time_to_child_table.py
+++ b/time_capture/patches/move_expected_working_time_to_child_table.py
@@ -6,9 +6,14 @@ def execute():
 		"Custom Field", {"dt": "Employee", "fieldname": "expected_daily_working_hours", "fieldtype": "Float"}
 	):
 		return
-	for e in frappe.db.get_all("Employee", filters={"expected_daily_working_hours": ["is", "set"]}):
-		print(f"Updating {e.name}")
-		employee = frappe.get_doc("Employee", e.name)
+
+	for employee_id in frappe.get_all("Employee", filters={"expected_daily_working_hours": ("is", "set")}, pluck="name")::
+		print(f"Updating {employee_id}")
+
+		employee = frappe.get_doc("Employee", employee_id)
+		if employee.expected_working_hours or not employee.expected_daily_working_hours:
+			continue
+
 		employee.append(
 			"expected_working_hours",
 			{

--- a/time_capture/scripts/employee.py
+++ b/time_capture/scripts/employee.py
@@ -1,5 +1,6 @@
 import frappe
 from frappe import _
+from frappe.utils import getdate
 
 
 def before_validate(doc, method):
@@ -7,7 +8,7 @@ def before_validate(doc, method):
 
 
 def validate_expected_working_hours(doc):
-	if not doc.date_of_joining == min(ewh.valid_from for ewh in doc.expected_working_hours):
+	if not doc.date_of_joining == min(getdate(ewh.valid_from) for ewh in doc.expected_working_hours):
 		frappe.throw(_("Date of Joining is not the same as the earliest date of Expected Working Hours."))
 
 

--- a/time_capture/scripts/employee.py
+++ b/time_capture/scripts/employee.py
@@ -18,7 +18,7 @@ def get_expected_working_hours(employee_id, date):
 	"""
 	return frappe.db.get_value(
 		"Employee Expected Working Hours",
-		filters={"parent": employee_id, "valid_from": ["<=", date]},
+		filters={"parent": employee_id, "valid_from": ("<=", date)},
 		fieldname="expected_daily_working_hours",
 		order_by="valid_from desc",
 	)

--- a/time_capture/scripts/employee.py
+++ b/time_capture/scripts/employee.py
@@ -1,0 +1,11 @@
+import frappe
+from frappe import _
+
+
+def before_validate(doc, method):
+	validate_expected_working_hours(doc)
+
+
+def validate_expected_working_hours(doc):
+	if not doc.date_of_joining == min(ewh.valid_from for ewh in doc.expected_working_hours):
+		frappe.throw(_("Date of Joining is not the same as the earliest date of Expected Working Hours."))

--- a/time_capture/scripts/employee.py
+++ b/time_capture/scripts/employee.py
@@ -9,3 +9,15 @@ def before_validate(doc, method):
 def validate_expected_working_hours(doc):
 	if not doc.date_of_joining == min(ewh.valid_from for ewh in doc.expected_working_hours):
 		frappe.throw(_("Date of Joining is not the same as the earliest date of Expected Working Hours."))
+
+
+def get_expected_working_hours(employee_id, date):
+	"""
+	Get the expected working hours for an employee on a specific date.
+	"""
+	return frappe.db.get_value(
+		"Employee Expected Working Hours",
+		filters={"parent": employee_id, "valid_from": ["<=", date]},
+		fieldname="expected_daily_working_hours",
+		order_by="valid_from desc",
+	)

--- a/time_capture/time_capture/doctype/employee_expected_working_hours/employee_expected_working_hours.json
+++ b/time_capture/time_capture/doctype/employee_expected_working_hours/employee_expected_working_hours.json
@@ -1,0 +1,45 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-05-14 14:56:54.878019",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "valid_from",
+  "expected_daily_working_hours"
+ ],
+ "fields": [
+  {
+   "columns": 4,
+   "fieldname": "valid_from",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "Valid From",
+   "reqd": 1
+  },
+  {
+   "columns": 6,
+   "fieldname": "expected_daily_working_hours",
+   "fieldtype": "Float",
+   "in_list_view": 1,
+   "label": "Expected Daily Working Hours",
+   "non_negative": 1,
+   "reqd": 1
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-05-14 15:44:30.974078",
+ "modified_by": "Administrator",
+ "module": "Time Capture",
+ "name": "Employee Expected Working Hours",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/time_capture/time_capture/doctype/employee_expected_working_hours/employee_expected_working_hours.py
+++ b/time_capture/time_capture/doctype/employee_expected_working_hours/employee_expected_working_hours.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, ALYF GmbH and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class EmployeeExpectedWorkingHours(Document):
+	pass


### PR DESCRIPTION
# Problem
The _Expected Daily Time_ can change from time to time. 
Currently the flexitime calculations relies on a static value (a float field). This can lead to data inconsistencies.

# Solution
Use a child table, instead of a float field, that allows date-specific _Expected Daily Time_.

# Follow Up
https://github.com/alyf-de/time_capture/pull/8 