### PR TITLE
fix(Attendance): use consistent unit (h) for HALF_DAY-comparison (DRC-189)

### DIFF
--- a/time_capture/scripts/attendance.py
+++ b/time_capture/scripts/attendance.py
@@ -47,7 +47,7 @@ def _calculate_attendance_metrics(doc, update_from_employee: bool = False):
 	if expected_working_hours_full_day and not update_from_employee:
 		HALF_DAY = expected_working_hours_full_day / 2
 		OVERTIME_FACTOR = 1.15
-		MAX_HALF_DAY = HALF_DAY * OVERTIME_FACTOR * 60 * 60
+		MAX_HALF_DAY = HALF_DAY * OVERTIME_FACTOR
 		doc.status = "Present" if doc.working_hours > MAX_HALF_DAY else "Half Day"
 
 	# Normal Working Day


### PR DESCRIPTION
# Follow Up

```python
half_day_attendances = frappe.db.get_all(
    "Attendance", filters={"status": "Half Day"}, fields=["name", "expected_working_hours", "working_hours", "flexitime", "status"]
)

for a in half_day_attendances:
    half_day_threshold = (a.expected_working_hours / 2) * 1.15
    if a.working_hours > half_day_threshold:
        frappe.db.set_value("Attendance", a.name, "status", "Present")

```