### PR TITLE
feat: show summary of leaves and hours for Employee in dialog (DRC-214)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -119,6 +119,7 @@
 		"after": true,
 		"qz": true,
 		"localforage": true,
-		"extend_cscript": true
+		"extend_cscript": true,
+		"time_capture": true
 	}
 }

--- a/time_capture/hooks.py
+++ b/time_capture/hooks.py
@@ -26,7 +26,7 @@ required_apps = ["erpnext", "hrms"]
 
 # include js, css files in header of desk.html
 # app_include_css = "/assets/time_capture/css/time_capture.css"
-# app_include_js = "/assets/time_capture/js/time_capture_utils.js"
+app_include_js = "/assets/time_capture/js/utils.js"
 
 # include js, css files in header of web template
 # web_include_css = "/assets/time_capture/css/time_capture.css"

--- a/time_capture/public/js/employee.js
+++ b/time_capture/public/js/employee.js
@@ -10,13 +10,10 @@ frappe.ui.form.on("Employee", {
 
 	onload: function (frm) {
 		if (frm.doc.name) {
-			frm.add_custom_button(
-				__("Time Capture & Leave Summary"),
-				function () {
-					// Reuse the existing function from utils.js
-					time_capture.utils.show_leave_and_time_summary_for_employee(frm.doc);
-				},
-			);
+			frm.add_custom_button(__("Time Capture & Leave Summary"), function () {
+				// Reuse the existing function from utils.js
+				time_capture.utils.show_leave_and_time_summary_for_employee(frm.doc);
+			});
 		}
 	},
 });

--- a/time_capture/public/js/employee.js
+++ b/time_capture/public/js/employee.js
@@ -14,7 +14,7 @@ frappe.ui.form.on("Employee", {
 				__("Time Capture & Leave Summary"),
 				function () {
 					// Reuse the existing function from utils.js
-					show_leave_and_time_summary_for_employee(frm.doc);
+					time_capture.utils.show_leave_and_time_summary_for_employee(frm.doc);
 				},
 			);
 		}

--- a/time_capture/public/js/employee.js
+++ b/time_capture/public/js/employee.js
@@ -9,15 +9,13 @@ frappe.ui.form.on("Employee", {
 	},
 
 	onload: function (frm) {
-		// Add custom button to show time capture and leave summary
 		if (frm.doc.name) {
 			frm.add_custom_button(
-				__("Show Summary"),
+				__("Time Capture & Leave Summary"),
 				function () {
 					// Reuse the existing function from utils.js
 					show_leave_and_time_summary(frm.doc);
 				},
-				__("Time Capture")
 			);
 		}
 	},

--- a/time_capture/public/js/employee.js
+++ b/time_capture/public/js/employee.js
@@ -14,7 +14,7 @@ frappe.ui.form.on("Employee", {
 				__("Time Capture & Leave Summary"),
 				function () {
 					// Reuse the existing function from utils.js
-					show_leave_and_time_summary(frm.doc);
+					show_leave_and_time_summary_for_employee(frm.doc);
 				},
 			);
 		}

--- a/time_capture/public/js/employee.js
+++ b/time_capture/public/js/employee.js
@@ -7,4 +7,18 @@ frappe.ui.form.on("Employee", {
 			}
 		);
 	},
+
+	onload: function (frm) {
+		// Add custom button to show time capture and leave summary
+		if (frm.doc.name) {
+			frm.add_custom_button(
+				__("Show Summary"),
+				function () {
+					// Reuse the existing function from utils.js
+					show_leave_and_time_summary(frm.doc);
+				},
+				__("Time Capture")
+			);
+		}
+	},
 });

--- a/time_capture/public/js/utils.js
+++ b/time_capture/public/js/utils.js
@@ -1,6 +1,8 @@
 // Copyright (c) 2024, Time Capture and contributors
 // For license information, please see license.txt
 
+frappe.provide("time_capture.utils");
+
 // Define the function in global scope
 frappe.ui.toolbar.show_time_capture_and_leave_summary = function () {
 	// Get current employee by user_id
@@ -15,7 +17,7 @@ frappe.ui.toolbar.show_time_capture_and_leave_summary = function () {
 		},
 		callback: function (r) {
 			if (r.message && r.message.name) {
-				show_leave_and_time_summary_for_employee(r.message);
+				time_capture.utils.show_leave_and_time_summary_for_employee(r.message);
 			} else {
 				frappe.msgprint({
 					title: __("Error"),
@@ -27,7 +29,7 @@ frappe.ui.toolbar.show_time_capture_and_leave_summary = function () {
 	});
 };
 
-function show_leave_and_time_summary_for_employee(employee) {
+time_capture.utils.show_leave_and_time_summary_for_employee = function(employee) {
 	// Call both functions in parallel to avoid duplicate calls
 	let leave_call = frappe.call({
 		method: "hrms.hr.doctype.leave_application.leave_application.get_leave_details",

--- a/time_capture/public/js/utils.js
+++ b/time_capture/public/js/utils.js
@@ -189,7 +189,9 @@ function create_summary_html(leave_details, lwps, time_summary, employee) {
 				<td style="width: 65%">
 					${__("Last Manual Balance Correction")}
 					<p style="font-size: 80%; !important">
-						${__("This could be (for example) a starting balance you took on from your previous time capture system.")}
+						${__(
+							"This could be (for example) a starting balance you took on from your previous time capture system."
+						)}
 					</p>
 				</td>
 				<td style="width: 35%">${time_summary.flexitime_correction}</td>
@@ -198,7 +200,9 @@ function create_summary_html(leave_details, lwps, time_summary, employee) {
 				<td>
 					${__("Current Balance")}
 					<p style="font-size: 80%; !important">
-						${__("This includes the last manual balance correction (if existing) and the sum of your working hours (minus your expected working hours).")}
+						${__(
+							"This includes the last manual balance correction (if existing) and the sum of your working hours (minus your expected working hours)."
+						)}
 					</p>
 				</td>
 				<td>${time_summary.current_balance || 0}</td>

--- a/time_capture/public/js/utils.js
+++ b/time_capture/public/js/utils.js
@@ -11,7 +11,7 @@ frappe.ui.toolbar.show_time_capture_and_leave_summary = function () {
 			filters: {
 				user_id: frappe.session.user,
 			},
-			fieldname: ["name", "employee_name", "company"],
+			fieldname: ["name"],
 		},
 		callback: function (r) {
 			if (r.message && r.message.name) {

--- a/time_capture/public/js/utils.js
+++ b/time_capture/public/js/utils.js
@@ -15,7 +15,7 @@ frappe.ui.toolbar.show_time_capture_and_leave_summary = function () {
 		},
 		callback: function (r) {
 			if (r.message && r.message.name) {
-				show_leave_and_time_summary(r.message);
+				show_leave_and_time_summary_for_employee(r.message);
 			} else {
 				frappe.msgprint({
 					title: __("Error"),
@@ -27,98 +27,110 @@ frappe.ui.toolbar.show_time_capture_and_leave_summary = function () {
 	});
 };
 
-function show_leave_and_time_summary(employee) {
-	// Get leave details
-	frappe.call({
+function show_leave_and_time_summary_for_employee(employee) {
+	// Call both functions in parallel to avoid duplicate calls
+	let leave_call = frappe.call({
 		method: "hrms.hr.doctype.leave_application.leave_application.get_leave_details",
 		args: {
 			employee: employee.name,
 			date: frappe.datetime.get_today(),
 		},
-		callback: function (r) {
-			let leave_details = r.message["leave_allocation"] || {};
-			let lwps = r.message["lwps"] || [];
+	});
 
-			// Get working time summary details
-			frappe.call({
-				method: "time_capture.scripts.summary_utils.get_working_time_summary_for_employee",
-				args: {
-					employee: employee.name,
-				},
-				callback: function (time_r) {
-					let time_summary = time_r.message || {};
-
-					// Create and show dialog
-					let dialog = new frappe.ui.Dialog({
-						size: "large",
-						fields: [
-							{
-								fieldtype: "HTML",
-								fieldname: "summary_html",
-								options: create_summary_html(
-									leave_details,
-									lwps,
-									time_summary,
-									employee
-								),
-							},
-						],
-					});
-
-					dialog.show();
-				},
-				error: function (err) {
-					// If time capture method fails, show only leave details
-					let dialog = new frappe.ui.Dialog({
-						title: __("Leave Summary"),
-						size: "large",
-						fields: [
-							{
-								fieldtype: "HTML",
-								fieldname: "summary_html",
-								options: create_summary_html(leave_details, lwps, {}, employee),
-							},
-						],
-					});
-
-					dialog.show();
-				},
-			});
-		},
-		error: function (err) {
-			// If leave details fail, show only working time summary
-			frappe.call({
-				method: "time_capture.scripts.summary_utils.get_working_time_summary_for_employee",
-				args: {
-					employee: employee.name,
-				},
-				callback: function (time_r) {
-					let time_summary = time_r.message || {};
-
-					let dialog = new frappe.ui.Dialog({
-						title: __("Time Capture Summary"),
-						size: "large",
-						fields: [
-							{
-								fieldtype: "HTML",
-								fieldname: "summary_html",
-								options: create_summary_html({}, [], time_summary, employee),
-							},
-						],
-					});
-
-					dialog.show();
-				},
-				error: function (err) {
-					frappe.msgprint({
-						title: __("Error"),
-						message: __("Unable to fetch summary data"),
-						indicator: "red",
-					});
-				},
-			});
+	let time_call = frappe.call({
+		method: "time_capture.scripts.summary_utils.get_working_time_summary_for_employee",
+		args: {
+			employee: employee.name,
 		},
 	});
+
+	// Handle both calls with Promise.all-like behavior
+	let leave_data = null;
+	let time_data = null;
+	let leave_error = null;
+	let time_error = null;
+	let completed_calls = 0;
+
+	function check_completion() {
+		completed_calls++;
+		if (completed_calls === 2) {
+			// Both calls completed, show dialog with available data
+			show_summary_dialog(leave_data, time_data, leave_error, time_error, employee);
+		}
+	}
+
+	// Handle leave details call
+	leave_call.then(function (r) {
+		leave_data = {
+			leave_allocation: r.message["leave_allocation"] || {},
+			lwps: r.message["lwps"] || []
+		};
+		check_completion();
+	}).catch(function (err) {
+		leave_error = err;
+		check_completion();
+	});
+
+	// Handle time summary call
+	time_call.then(function (r) {
+		time_data = r.message || {};
+		check_completion();
+	}).catch(function (err) {
+		time_error = err;
+		check_completion();
+	});
+}
+
+function show_summary_dialog(leave_data, time_data, leave_error, time_error, employee) {
+	let dialog_title = __("Summary");
+	let leave_details = {};
+	let lwps = [];
+	let time_summary = {};
+
+	// Process leave data if available
+	if (leave_data && !leave_error) {
+		leave_details = leave_data.leave_allocation;
+		lwps = leave_data.lwps;
+	}
+
+	// Process time data if available
+	if (time_data && !time_error) {
+		time_summary = time_data;
+	}
+
+	// Determine dialog title based on available data
+	if (leave_error && time_error) {
+		dialog_title = __("Error");
+	} else if (leave_error) {
+		dialog_title = __("Time Capture Summary");
+	} else if (time_error) {
+		dialog_title = __("Leave Summary");
+	}
+
+	// Show error if both calls failed
+	if (leave_error && time_error) {
+		frappe.msgprint({
+			title: __("Error"),
+			message: __("Unable to fetch summary data"),
+			indicator: "red",
+		});
+		return;
+	}
+
+	// Create and show dialog
+	let dialog = new frappe.ui.Dialog({
+		title: dialog_title,
+		size: "large",
+		fields: [
+			{
+				fieldtype: "HTML",
+				fieldname: "summary_html",
+				options: create_summary_html(leave_details, lwps, time_summary, employee),
+			},
+		],
+	});
+
+	dialog.show();
 }
 
 function create_summary_html(leave_details, lwps, time_summary, employee) {
@@ -171,7 +183,7 @@ function create_summary_html(leave_details, lwps, time_summary, employee) {
 				<td style="width: 65%">
 					${__("Last Manual Balance Correction")}
 					<p style="font-size: 80%; !important">
-						${__("Example: A starting balance after you switched this time capture system.")}
+						${__("This could be (for example) a starting balance you took on from your previous time capture system.")}
 					</p>
 				</td>
 				<td style="width: 35%">${time_summary.flexitime_correction}</td>
@@ -206,13 +218,11 @@ function create_summary_html(leave_details, lwps, time_summary, employee) {
 			<tr>
 				<td>
 					${__("Overdue Time Captures")}
-				</td>
-				<td>
-					${time_summary.open_time_captures || 0}
 					<p style="font-size: 80%; !important">
 						${__("Past time captures, that are not yet submitted. These count as absent and reduce the balance.")}
 					</p>
 				</td>
+				<td>${time_summary.open_time_captures || 0}</td>
 			</tr>
 		`;
 

--- a/time_capture/public/js/utils.js
+++ b/time_capture/public/js/utils.js
@@ -50,7 +50,6 @@ function show_leave_and_time_summary(employee) {
 
 					// Create and show dialog
 					let dialog = new frappe.ui.Dialog({
-						title: __("Time Capture & Leave Summary"),
 						size: "large",
 						fields: [
 							{
@@ -167,50 +166,39 @@ function create_summary_html(leave_details, lwps, time_summary, employee) {
 						<tbody>
 	`;
 
-	// Add working time details
-	if (time_summary && Object.keys(time_summary).length > 0) {
-		let correction_date = time_summary.flexitime_correction
-			? time_summary.flexitime_correction.date
-			: "-";
-		let correction_value = time_summary.flexitime_correction
-			? time_summary.flexitime_correction.flexitime_hours
-			: 0;
-
-		// Format correction display
-		let correction_display = "-";
-		if (correction_value && correction_date && correction_date !== "-") {
-			correction_display = `${correction_value} on ${correction_date}`;
-		} else if (correction_value) {
-			correction_display = `${correction_value}`;
-		} else if (correction_date && correction_date !== "-") {
-			correction_display = correction_date;
-		}
-
 		html += `
 			<tr>
-				<td style="width: 65%">${__("Last Manual Correction")}</td>
-				<td style="width: 35%">${correction_display}</td>
+				<td style="width: 65%">${__("Last Manual Balance Correction")}</td>
+				<td style="width: 35%">${time_summary.flexitime_correction}</td>
 			</tr>
-			<tr>
+			<tr style="font-weight: bold;">
 				<td>${__("Current Balance")}</td>
 				<td>${time_summary.current_balance || 0}</td>
 			</tr>
 			<tr>
-				<td>${__("Planned Overtime Reduction (Future)")}</td>
+				<td>${__("Planned Overtime Reduction")}</td>
 				<td>${time_summary.future_balance_changes || 0}</td>
 			</tr>
 			<tr>
-				<td>${__("Balance after planned overtime reduction")}</td>
+				<td>${__("Future Balance (after planned reduction)")}</td>
 				<td>${time_summary.future_balance || 0}</td>
 			</tr>
+			<tr>
+				<td>
+					${__("Overdue Time Captures")}
+					<p style="font-size: 80%; !important">
+						${__("Time Captures that are overdue and not submitted")}
+					</p>
+				</td>
+				<td>${time_summary.open_time_captures || 0}</td>
+			</tr>
 		`;
-	} else {
+
 		html += `
 			<tr>
 				<td colspan="2" class="text-center">${__("No working time data found")}</td>
 			</tr>
 		`;
-	}
 
 	html += `
 						</tbody>

--- a/time_capture/public/js/utils.js
+++ b/time_capture/public/js/utils.js
@@ -171,16 +171,16 @@ function create_summary_html(leave_details, lwps, time_summary, employee) {
 				<td style="width: 65%">
 					${__("Last Manual Balance Correction")}
 					<p style="font-size: 80%; !important">
-						${__("This is the last manual balance correction, that was applied to the balance. It usually represents a starting balance after you switched the time capture system.")}
+						${__("Example: A starting balance after you switched this time capture system.")}
 					</p>
 				</td>
 				<td style="width: 35%">${time_summary.flexitime_correction}</td>
 			</tr>
-			<tr style="font-weight: bold;">
+			<tr">
 				<td>
 					${__("Current Balance")}
 					<p style="font-size: 80%; !important">
-						${__("This is the current balance, that includes the last manual balance correction (if existing) and the attendance sum.")}
+						${__("This includes the last manual balance correction (if existing) and the sum of your working hours (minus your expected working hours).")}
 					</p>
 				</td>
 				<td>${time_summary.current_balance || 0}</td>
@@ -189,7 +189,7 @@ function create_summary_html(leave_details, lwps, time_summary, employee) {
 				<td>
 					${__("Planned Overtime Reduction")}
 					<p style="font-size: 80%; !important">
-						${__("Future overtime reductions, that are already planned.")}
+						${__("Future, approved overtime reductions.")}
 					</p>
 				</td>
 				<td>${time_summary.future_balance_changes || 0}</td>
@@ -207,15 +207,26 @@ function create_summary_html(leave_details, lwps, time_summary, employee) {
 				<td>
 					${__("Overdue Time Captures")}
 				</td>
-				<td>${time_summary.open_time_captures || 0}</td>
+				<td>
+					${time_summary.open_time_captures || 0}
+					<p style="font-size: 80%; !important">
+						${__("Past time captures, that are not yet submitted. These count as absent and reduce the balance.")}
+					</p>
+				</td>
 			</tr>
 		`;
 
-		html += `
-			<tr>
-				<td colspan="2" class="text-center">${__("No working time data found")}</td>
-			</tr>
-		`;
+		// Only show "No working time data found" if there's no data
+		if (!time_summary || Object.keys(time_summary).length === 0 ||
+			(!time_summary.flexitime_correction && !time_summary.current_balance &&
+			 !time_summary.future_balance_changes && !time_summary.future_balance &&
+			 !time_summary.open_time_captures)) {
+			html += `
+				<tr>
+					<td colspan="2" class="text-center">${__("No working time data found")}</td>
+				</tr>
+			`;
+		}
 
 	html += `
 						</tbody>

--- a/time_capture/public/js/utils.js
+++ b/time_capture/public/js/utils.js
@@ -1,0 +1,224 @@
+// Copyright (c) 2024, Time Capture and contributors
+// For license information, please see license.txt
+
+// Define the function in global scope
+frappe.ui.toolbar.show_time_capture_and_leave_summary = function () {
+	// Get current employee by user_id
+	frappe.call({
+		method: "frappe.client.get_value",
+		args: {
+			doctype: "Employee",
+			filters: {
+				user_id: frappe.session.user,
+			},
+			fieldname: ["name", "employee_name", "company"],
+		},
+		callback: function (r) {
+			if (r.message && r.message.name) {
+				show_leave_and_time_summary(r.message);
+			} else {
+				frappe.msgprint({
+					title: __("Error"),
+					message: __("No employee found for current user"),
+					indicator: "red",
+				});
+			}
+		},
+	});
+};
+
+function show_leave_and_time_summary(employee) {
+	// Get leave details
+	frappe.call({
+		method: "hrms.hr.doctype.leave_application.leave_application.get_leave_details",
+		args: {
+			employee: employee.name,
+			date: frappe.datetime.get_today(),
+		},
+		callback: function (r) {
+			let leave_details = r.message["leave_allocation"] || {};
+			let lwps = r.message["lwps"] || [];
+
+			// Get working time summary details
+			frappe.call({
+				method: "time_capture.scripts.summary_utils.get_working_time_summary_for_employee",
+				args: {
+					employee: employee.name,
+				},
+				callback: function (time_r) {
+					let time_summary = time_r.message || {};
+
+					// Create and show dialog
+					let dialog = new frappe.ui.Dialog({
+						title: __("Time Capture & Leave Summary"),
+						size: "large",
+						fields: [
+							{
+								fieldtype: "HTML",
+								fieldname: "summary_html",
+								options: create_summary_html(
+									leave_details,
+									lwps,
+									time_summary,
+									employee
+								),
+							},
+						],
+					});
+
+					dialog.show();
+				},
+				error: function (err) {
+					// If time capture method fails, show only leave details
+					let dialog = new frappe.ui.Dialog({
+						title: __("Leave Summary"),
+						size: "large",
+						fields: [
+							{
+								fieldtype: "HTML",
+								fieldname: "summary_html",
+								options: create_summary_html(leave_details, lwps, {}, employee),
+							},
+						],
+					});
+
+					dialog.show();
+				},
+			});
+		},
+		error: function (err) {
+			// If leave details fail, show only working time summary
+			frappe.call({
+				method: "time_capture.scripts.summary_utils.get_working_time_summary_for_employee",
+				args: {
+					employee: employee.name,
+				},
+				callback: function (time_r) {
+					let time_summary = time_r.message || {};
+
+					let dialog = new frappe.ui.Dialog({
+						title: __("Time Capture Summary"),
+						size: "large",
+						fields: [
+							{
+								fieldtype: "HTML",
+								fieldname: "summary_html",
+								options: create_summary_html({}, [], time_summary, employee),
+							},
+						],
+					});
+
+					dialog.show();
+				},
+				error: function (err) {
+					frappe.msgprint({
+						title: __("Error"),
+						message: __("Unable to fetch summary data"),
+						indicator: "red",
+					});
+				},
+			});
+		},
+	});
+}
+
+function create_summary_html(leave_details, lwps, time_summary, employee) {
+	let html = `
+		<div class="row">
+			<div class="col-md-12">
+				<h4>${__("Leave Summary")}</h4>
+				<div class="table-responsive">
+					<table class="table table-bordered">
+						<thead>
+							<tr>
+								<th>${__("Leave Type")}</th>
+								<th>${__("Allocated")}</th>
+								<th>${__("Used")}</th>
+								<th>${__("Balance")}</th>
+							</tr>
+						</thead>
+						<tbody>
+	`;
+
+	// Add leave details
+	Object.keys(leave_details).forEach((leave_type) => {
+		let details = leave_details[leave_type];
+		html += `
+			<tr>
+				<td>${leave_type}</td>
+				<td>${details.total_leaves || 0}</td>
+				<td>${details.leaves_taken || 0}</td>
+				<td>${details.remaining_leaves || 0}</td>
+			</tr>
+		`;
+	});
+
+	html += `
+						</tbody>
+					</table>
+				</div>
+			</div>
+		</div>
+		<div class="row" style="margin-top: 20px;">
+			<div class="col-md-12">
+				<h4>${__("Working Time Summary")}</h4>
+				<div class="table-responsive">
+					<table class="table table-bordered">
+						<tbody>
+	`;
+
+	// Add working time details
+	if (time_summary && Object.keys(time_summary).length > 0) {
+		let correction_date = time_summary.flexitime_correction
+			? time_summary.flexitime_correction.date
+			: "-";
+		let correction_value = time_summary.flexitime_correction
+			? time_summary.flexitime_correction.flexitime_hours
+			: 0;
+
+		// Format correction display
+		let correction_display = "-";
+		if (correction_value && correction_date && correction_date !== "-") {
+			correction_display = `${correction_value} on ${correction_date}`;
+		} else if (correction_value) {
+			correction_display = `${correction_value}`;
+		} else if (correction_date && correction_date !== "-") {
+			correction_display = correction_date;
+		}
+
+		html += `
+			<tr>
+				<td style="width: 65%">${__("Last Manual Correction")}</td>
+				<td style="width: 35%">${correction_display}</td>
+			</tr>
+			<tr>
+				<td>${__("Current Balance")}</td>
+				<td>${time_summary.current_balance || 0}</td>
+			</tr>
+			<tr>
+				<td>${__("Planned Overtime Reduction (Future)")}</td>
+				<td>${time_summary.future_balance_changes || 0}</td>
+			</tr>
+			<tr>
+				<td>${__("Balance after planned overtime reduction")}</td>
+				<td>${time_summary.future_balance || 0}</td>
+			</tr>
+		`;
+	} else {
+		html += `
+			<tr>
+				<td colspan="2" class="text-center">${__("No working time data found")}</td>
+			</tr>
+		`;
+	}
+
+	html += `
+						</tbody>
+					</table>
+				</div>
+			</div>
+		</div>
+	`;
+
+	return html;
+}

--- a/time_capture/public/js/utils.js
+++ b/time_capture/public/js/utils.js
@@ -168,27 +168,44 @@ function create_summary_html(leave_details, lwps, time_summary, employee) {
 
 		html += `
 			<tr>
-				<td style="width: 65%">${__("Last Manual Balance Correction")}</td>
+				<td style="width: 65%">
+					${__("Last Manual Balance Correction")}
+					<p style="font-size: 80%; !important">
+						${__("This is the last manual balance correction, that was applied to the balance. It usually represents a starting balance after you switched the time capture system.")}
+					</p>
+				</td>
 				<td style="width: 35%">${time_summary.flexitime_correction}</td>
 			</tr>
 			<tr style="font-weight: bold;">
-				<td>${__("Current Balance")}</td>
+				<td>
+					${__("Current Balance")}
+					<p style="font-size: 80%; !important">
+						${__("This is the current balance, that includes the last manual balance correction (if existing) and the attendance sum.")}
+					</p>
+				</td>
 				<td>${time_summary.current_balance || 0}</td>
 			</tr>
 			<tr>
-				<td>${__("Planned Overtime Reduction")}</td>
+				<td>
+					${__("Planned Overtime Reduction")}
+					<p style="font-size: 80%; !important">
+						${__("Future overtime reductions, that are already planned.")}
+					</p>
+				</td>
 				<td>${time_summary.future_balance_changes || 0}</td>
 			</tr>
 			<tr>
-				<td>${__("Future Balance (after planned reduction)")}</td>
+				<td>
+					${__("Future Balance (after planned reduction)")}
+					<p style="font-size: 80%; !important">
+						${__("This is the projected balance, that includes planned overtime reductions")}
+					</p>
+				</td>
 				<td>${time_summary.future_balance || 0}</td>
 			</tr>
 			<tr>
 				<td>
 					${__("Overdue Time Captures")}
-					<p style="font-size: 80%; !important">
-						${__("Time Captures that are overdue and not submitted")}
-					</p>
 				</td>
 				<td>${time_summary.open_time_captures || 0}</td>
 			</tr>

--- a/time_capture/public/js/utils.js
+++ b/time_capture/public/js/utils.js
@@ -189,20 +189,16 @@ function create_summary_html(leave_details, lwps, time_summary, employee) {
 				<td style="width: 65%">
 					${__("Last Manual Balance Correction")}
 					<p style="font-size: 80%; !important">
-						${__(
-							"This could be (for example) a starting balance you took on from your previous time capture system."
-						)}
+						${__("This could be (for example) a starting balance you took on from your previous time capture system.")}
 					</p>
 				</td>
 				<td style="width: 35%">${time_summary.flexitime_correction}</td>
 			</tr>
-			<tr">
+			<tr>
 				<td>
 					${__("Current Balance")}
 					<p style="font-size: 80%; !important">
-						${__(
-							"This includes the last manual balance correction (if existing) and the sum of your working hours (minus your expected working hours)."
-						)}
+						${__("This includes the last manual balance correction (if existing) and the sum of your working hours (minus your expected working hours).")}
 					</p>
 				</td>
 				<td>${time_summary.current_balance || 0}</td>

--- a/time_capture/public/js/utils.js
+++ b/time_capture/public/js/utils.js
@@ -29,7 +29,7 @@ frappe.ui.toolbar.show_time_capture_and_leave_summary = function () {
 	});
 };
 
-time_capture.utils.show_leave_and_time_summary_for_employee = function(employee) {
+time_capture.utils.show_leave_and_time_summary_for_employee = function (employee) {
 	// Call both functions in parallel to avoid duplicate calls
 	let leave_call = frappe.call({
 		method: "hrms.hr.doctype.leave_application.leave_application.get_leave_details",
@@ -62,26 +62,30 @@ time_capture.utils.show_leave_and_time_summary_for_employee = function(employee)
 	}
 
 	// Handle leave details call
-	leave_call.then(function (r) {
-		leave_data = {
-			leave_allocation: r.message["leave_allocation"] || {},
-			lwps: r.message["lwps"] || []
-		};
-		check_completion();
-	}).catch(function (err) {
-		leave_error = err;
-		check_completion();
-	});
+	leave_call
+		.then(function (r) {
+			leave_data = {
+				leave_allocation: r.message["leave_allocation"] || {},
+				lwps: r.message["lwps"] || [],
+			};
+			check_completion();
+		})
+		.catch(function (err) {
+			leave_error = err;
+			check_completion();
+		});
 
 	// Handle time summary call
-	time_call.then(function (r) {
-		time_data = r.message || {};
-		check_completion();
-	}).catch(function (err) {
-		time_error = err;
-		check_completion();
-	});
-}
+	time_call
+		.then(function (r) {
+			time_data = r.message || {};
+			check_completion();
+		})
+		.catch(function (err) {
+			time_error = err;
+			check_completion();
+		});
+};
 
 function show_summary_dialog(leave_data, time_data, leave_error, time_error, employee) {
 	let dialog_title = __("Summary");
@@ -180,12 +184,14 @@ function create_summary_html(leave_details, lwps, time_summary, employee) {
 						<tbody>
 	`;
 
-		html += `
+	html += `
 			<tr>
 				<td style="width: 65%">
 					${__("Last Manual Balance Correction")}
 					<p style="font-size: 80%; !important">
-						${__("This could be (for example) a starting balance you took on from your previous time capture system.")}
+						${__(
+							"This could be (for example) a starting balance you took on from your previous time capture system."
+						)}
 					</p>
 				</td>
 				<td style="width: 35%">${time_summary.flexitime_correction}</td>
@@ -194,7 +200,9 @@ function create_summary_html(leave_details, lwps, time_summary, employee) {
 				<td>
 					${__("Current Balance")}
 					<p style="font-size: 80%; !important">
-						${__("This includes the last manual balance correction (if existing) and the sum of your working hours (minus your expected working hours).")}
+						${__(
+							"This includes the last manual balance correction (if existing) and the sum of your working hours (minus your expected working hours)."
+						)}
 					</p>
 				</td>
 				<td>${time_summary.current_balance || 0}</td>
@@ -221,24 +229,31 @@ function create_summary_html(leave_details, lwps, time_summary, employee) {
 				<td>
 					${__("Overdue Time Captures")}
 					<p style="font-size: 80%; !important">
-						${__("Past time captures, that are not yet submitted. These count as absent and reduce the balance.")}
+						${__(
+							"Past time captures, that are not yet submitted. These count as absent and reduce the balance."
+						)}
 					</p>
 				</td>
 				<td>${time_summary.open_time_captures || 0}</td>
 			</tr>
 		`;
 
-		// Only show "No working time data found" if there's no data
-		if (!time_summary || Object.keys(time_summary).length === 0 ||
-			(!time_summary.flexitime_correction && !time_summary.current_balance &&
-			 !time_summary.future_balance_changes && !time_summary.future_balance &&
-			 !time_summary.open_time_captures)) {
-			html += `
+	// Only show "No working time data found" if there's no data
+	if (
+		!time_summary ||
+		Object.keys(time_summary).length === 0 ||
+		(!time_summary.flexitime_correction &&
+			!time_summary.current_balance &&
+			!time_summary.future_balance_changes &&
+			!time_summary.future_balance &&
+			!time_summary.open_time_captures)
+	) {
+		html += `
 				<tr>
 					<td colspan="2" class="text-center">${__("No working time data found")}</td>
 				</tr>
 			`;
-		}
+	}
 
 	html += `
 						</tbody>

--- a/time_capture/scripts/summary_utils.py
+++ b/time_capture/scripts/summary_utils.py
@@ -35,7 +35,11 @@ def _get_last_flexitime_correction(employee: str) -> float:
 	""" """
 	flexitime_correction = frappe.db.get_value(
 		"Flexitime Correction",
-		filters={"employee": employee, "docstatus": 1},
+		filters={
+			"employee": employee,
+			"docstatus": 1,
+			"date": ("<=", frappe.utils.getdate()),
+		},
 		fieldname=["flexitime_hours", "date"],
 		order_by="date DESC",
 		as_dict=True,

--- a/time_capture/scripts/summary_utils.py
+++ b/time_capture/scripts/summary_utils.py
@@ -73,7 +73,7 @@ def _get_flexitime_sum_from_attendance(
 		filters=filters,
 	)
 
-	return 0 if not result or not result[0].get("flexitime_sum") else result.get("flexitime_sum")
+	return 0 if not result or not result[0].get("flexitime_sum") else result[0].get("flexitime_sum")
 
 
 def beautify_report_data(working_time_summary: dict) -> dict:

--- a/time_capture/scripts/summary_utils.py
+++ b/time_capture/scripts/summary_utils.py
@@ -77,7 +77,7 @@ def beautify_report_data(working_time_summary: dict) -> dict:
 		flexitime_correction = "-"
 
 	# Beautify the other values
-	working_time_summary["last_manual_correction"] = flexitime_correction
+	working_time_summary["flexitime_correction"] = flexitime_correction
 	working_time_summary["current_balance"] = _format_duration_hours(
 		working_time_summary.get("current_balance")
 	)

--- a/time_capture/scripts/summary_utils.py
+++ b/time_capture/scripts/summary_utils.py
@@ -13,9 +13,7 @@ def get_working_time_summary_for_employee(employee: str, beautified: bool = True
 	today = frappe.utils.getdate()
 
 	flexitime_correction = _get_last_flexitime_correction(employee)
-	attendance_sum = _get_flexitime_sum_from_attendance(
-		employee, flexitime_correction.get("date"), today
-	)
+	attendance_sum = _get_flexitime_sum_from_attendance(employee, flexitime_correction.get("date"), today)
 	current_balance = (flexitime_correction.get("flexitime_hours") or 0) + (attendance_sum or 0)
 	future_balance_changes = _get_flexitime_sum_from_attendance(employee, today)
 	future_balance = current_balance + future_balance_changes

--- a/time_capture/scripts/summary_utils.py
+++ b/time_capture/scripts/summary_utils.py
@@ -72,7 +72,7 @@ def beautify_report_data(working_time_summary: dict) -> dict:
 	if flexitime_correction.get("flexitime_hours") and flexitime_correction.get("date"):
 		formatted_hours = _format_duration_hours(flexitime_correction.get("flexitime_hours"))
 		formatted_date = frappe.utils.format_date(flexitime_correction.get("date"), "dd.MM.YYYY")
-		flexitime_correction = _("{0} on {1}").format(formatted_hours, formatted_date)
+		flexitime_correction = _("{0} (on {1})").format(formatted_hours, formatted_date)
 	else:
 		flexitime_correction = "-"
 

--- a/time_capture/scripts/summary_utils.py
+++ b/time_capture/scripts/summary_utils.py
@@ -55,7 +55,9 @@ def _get_last_flexitime_correction(employee: str) -> float:
 def _get_flexitime_sum_from_attendance(
 	employee: str, from_date: str | None = None, to_date: str | None = None
 ) -> float:
-	""" """
+	"""
+	Get the sum of flexitime for submitted Attendances for an employee.
+	"""
 	filters = [
 		["employee", "=", employee],
 		["docstatus", "=", 1],

--- a/time_capture/scripts/summary_utils.py
+++ b/time_capture/scripts/summary_utils.py
@@ -4,20 +4,25 @@ from frappe import _
 
 @frappe.whitelist()
 def get_working_time_summary_for_employee(employee: str, beautified: bool = True) -> dict:
+	"""
+	Returns a dictionary with current leave and working time summary for an employee.
+	Considered DocTypes: Leave Ledger, Attendance, Flexitime Correction, Time Capture.
+	Depending on beautified, the values are either human-readable strings machine-readable floats.
+	"""
 	frappe.has_permission("Employee", doc=employee, throw=True)
+	today = frappe.utils.getdate()
 
 	flexitime_correction = _get_last_flexitime_correction(employee)
 	attendance_sum = _get_flexitime_sum_from_attendance(
-		employee, flexitime_correction.get("date"), frappe.utils.getdate()
+		employee, flexitime_correction.get("date"), today
 	)
 	current_balance = (flexitime_correction.get("flexitime_hours") or 0) + (attendance_sum or 0)
-	future_balance_changes = _get_flexitime_sum_from_attendance(employee, frappe.utils.getdate())
-	# these changes are mainly expected through planned overtime reductions
+	future_balance_changes = _get_flexitime_sum_from_attendance(employee, today)
 	future_balance = current_balance + future_balance_changes
 	open_time_captures = len(
 		frappe.db.get_all(
 			"Time Capture",
-			filters={"employee": employee, "docstatus": 0},
+			filters={"employee": employee, "docstatus": 0, "date": ("<=", today)},
 		)
 	)
 
@@ -32,7 +37,9 @@ def get_working_time_summary_for_employee(employee: str, beautified: bool = True
 
 
 def _get_last_flexitime_correction(employee: str) -> float:
-	""" """
+	"""
+	Returns flexitime_hours and date of the last (today or before) Flexitime Correction.
+	"""
 	flexitime_correction = frappe.db.get_value(
 		"Flexitime Correction",
 		filters={
@@ -64,14 +71,15 @@ def _get_flexitime_sum_from_attendance(
 		"Attendance",
 		fields=["SUM(flexitime) as flexitime_sum"],
 		filters=filters,
-		as_list=True,
 	)
 
-	return result[0][0] if result and result[0][0] else 0
+	return 0 if not result or not result[0].get("flexitime_sum") else result.get("flexitime_sum")
 
 
 def beautify_report_data(working_time_summary: dict) -> dict:
-	# Beautify the Flexitime Correction
+	"""
+	Format the summary dictionary into UX-friendly strings.
+	"""
 	flexitime_correction = working_time_summary.get("flexitime_correction", {})
 	if flexitime_correction.get("flexitime_hours") and flexitime_correction.get("date"):
 		formatted_hours = _format_duration_hours(flexitime_correction.get("flexitime_hours"))
@@ -104,6 +112,7 @@ def _format_duration_hours(hours: float | None) -> str:
 	- 7.5 -> "7:30 h"
 	- 0.0 or None -> "0:00 h"
 	- 1.024 -> "1:01 h" (rounded to nearest minute)
+	frappe.format_duration was not used because we don't want seconds.
 	"""
 	if hours is None or hours == 0:
 		return "0:00 h"

--- a/time_capture/scripts/summary_utils.py
+++ b/time_capture/scripts/summary_utils.py
@@ -1,8 +1,9 @@
 import frappe
+from frappe import _
 
 
 @frappe.whitelist()
-def get_working_time_summary_for_employee(employee: str) -> dict:
+def get_working_time_summary_for_employee(employee: str, beautified: bool = True) -> dict:
 	frappe.has_permission("Employee", doc=employee, throw=True)
 
 	flexitime_correction = _get_last_flexitime_correction(employee)
@@ -20,13 +21,14 @@ def get_working_time_summary_for_employee(employee: str) -> dict:
 		)
 	)
 
-	return {
+	summary = {
 		"flexitime_correction": flexitime_correction,
 		"current_balance": current_balance,
 		"future_balance_changes": future_balance_changes,
 		"future_balance": future_balance,
 		"open_time_captures": open_time_captures,
 	}
+	return beautify_report_data(summary) if beautified else summary
 
 
 def _get_last_flexitime_correction(employee: str) -> float:
@@ -62,3 +64,59 @@ def _get_flexitime_sum_from_attendance(
 	)
 
 	return result[0][0] if result and result[0][0] else 0
+
+
+def beautify_report_data(working_time_summary: dict) -> dict:
+	# Beautify the Flexitime Correction
+	flexitime_correction = working_time_summary.get("flexitime_correction", {})
+	if flexitime_correction.get("flexitime_hours") and flexitime_correction.get("date"):
+		formatted_hours = _format_duration_hours(flexitime_correction.get("flexitime_hours"))
+		formatted_date = frappe.utils.format_date(flexitime_correction.get("date"), "dd.MM.YYYY")
+		flexitime_correction = _("{0} on {1}").format(formatted_hours, formatted_date)
+	else:
+		flexitime_correction = "-"
+
+	# Beautify the other values
+	working_time_summary["last_manual_correction"] = flexitime_correction
+	working_time_summary["current_balance"] = _format_duration_hours(
+		working_time_summary.get("current_balance")
+	)
+	working_time_summary["future_balance_changes"] = _format_duration_hours(
+		working_time_summary.get("future_balance_changes")
+	)
+	working_time_summary["future_balance"] = _format_duration_hours(
+		working_time_summary.get("future_balance")
+	)
+	working_time_summary["open_time_captures"] = working_time_summary.get("open_time_captures")
+
+	return working_time_summary
+
+
+def _format_duration_hours(hours: float | None) -> str:
+	"""
+	Format float hours into a nice duration format.
+	Examples:
+	- 1.5 -> "1:30 h"
+	- 7.5 -> "7:30 h"
+	- 0.0 or None -> "0:00 h"
+	- 1.024 -> "1:01 h" (rounded to nearest minute)
+	"""
+	if hours is None or hours == 0:
+		return "0:00 h"
+
+	# Handle negative values
+	is_negative = hours < 0
+	abs_hours = abs(hours)
+
+	# Convert to hours and minutes
+	total_hours = int(abs_hours)
+	minutes = round((abs_hours % 1) * 60)
+
+	# Handle minute overflow (e.g., 1.99 hours becomes 2:00h)
+	if minutes >= 60:
+		total_hours += 1
+		minutes = 0
+
+	# Add negative sign if needed
+	sign = "-" if is_negative else ""
+	return f"{sign}{total_hours}:{minutes:02d} h"

--- a/time_capture/scripts/summary_utils.py
+++ b/time_capture/scripts/summary_utils.py
@@ -1,0 +1,64 @@
+import frappe
+
+
+@frappe.whitelist()
+def get_working_time_summary_for_employee(employee: str) -> dict:
+	frappe.has_permission("Employee", doc=employee, throw=True)
+
+	flexitime_correction = _get_last_flexitime_correction(employee)
+	attendance_sum = _get_flexitime_sum_from_attendance(
+		employee, flexitime_correction.get("date"), frappe.utils.getdate()
+	)
+	current_balance = (flexitime_correction.get("flexitime_hours") or 0) + (attendance_sum or 0)
+	future_balance_changes = _get_flexitime_sum_from_attendance(employee, frappe.utils.getdate())
+	# these changes are mainly expected through planned overtime reductions
+	future_balance = current_balance + future_balance_changes
+	open_time_captures = len(
+		frappe.db.get_all(
+			"Time Capture",
+			filters={"employee": employee, "docstatus": 0},
+		)
+	)
+
+	return {
+		"flexitime_correction": flexitime_correction,
+		"current_balance": current_balance,
+		"future_balance_changes": future_balance_changes,
+		"future_balance": future_balance,
+		"open_time_captures": open_time_captures,
+	}
+
+
+def _get_last_flexitime_correction(employee: str) -> float:
+	""" """
+	flexitime_correction = frappe.db.get_value(
+		"Flexitime Correction",
+		filters={"employee": employee, "docstatus": 1},
+		fieldname=["flexitime_hours", "date"],
+		order_by="date DESC",
+		as_dict=True,
+	)
+	return flexitime_correction or {"flexitime_hours": 0, "date": None}
+
+
+def _get_flexitime_sum_from_attendance(
+	employee: str, from_date: str | None = None, to_date: str | None = None
+) -> float:
+	""" """
+	filters = [
+		["employee", "=", employee],
+		["docstatus", "=", 1],
+	]
+	if from_date:
+		filters.append(["attendance_date", ">=", from_date])
+	if to_date:
+		filters.append(["attendance_date", "<=", to_date])
+
+	result = frappe.get_list(
+		"Attendance",
+		fields=["SUM(flexitime) as flexitime_sum"],
+		filters=filters,
+		as_list=True,
+	)
+
+	return result[0][0] if result and result[0][0] else 0


### PR DESCRIPTION
# Problem
As leave budgets are closely connected to flexitime numbers, the users needed an overview, where they could see both.

# Solution
Create an easily accessible overview of the current balances.

## Example Result
<img width="783" height="809" alt="image" src="https://github.com/user-attachments/assets/c1b4f490-1cb6-4f98-b0d2-4e0d9afebd2e" />

## Details
The overview is in a dialog (filled with HTML) that is reachable in two ways:

- via custom button in **Employee**'s form.
- via navbar option (has to be configured individually!)

**How to configure the navbar option**
As a "System Manager" or Admin:
Go to **Navbar Settings** -> Add a new row to _Settings Dropdown_ -> configure the row as in the following example:
<img width="1015" height="530" alt="image" src="https://github.com/user-attachments/assets/7c82b3d5-b6c4-4ce4-84e2-1f0f5526f298" />
`frappe.ui.toolbar.show_time_capture_and_leave_summary()`

Result:
<img width="220" height="303" alt="image" src="https://github.com/user-attachments/assets/01a820f4-2980-4819-8f5b-22bb70f4f9e2" />

# Todo

- [x] Test (different tests) -> With Flexitime Correction, with future flexitime correciton, without correction, with planned overtime reduction, ...
- [x] Hübscher machen
- [x] Refactor
- [x] Document