### PR TITLE
fix(Leave Application): delete Time Captures also on change of Attendance

### DIFF
--- a/time_capture/hooks.py
+++ b/time_capture/hooks.py
@@ -139,9 +139,7 @@ after_install = "time_capture.install.after_install"
 
 doc_events = {
 	"Attendance": {
-		"before_insert": "time_capture.scripts.attendance.before_insert",
 		"on_submit": "time_capture.scripts.attendance.on_submit",
-		"before_update_after_submit": "time_capture.scripts.attendance.before_update_after_submit",
 		"on_change": "time_capture.scripts.attendance.on_change",
 		"on_cancel": "time_capture.scripts.attendance.on_cancel",
 	},

--- a/time_capture/hooks.py
+++ b/time_capture/hooks.py
@@ -142,6 +142,7 @@ doc_events = {
 		"before_insert": "time_capture.scripts.attendance.before_insert",
 		"on_submit": "time_capture.scripts.attendance.on_submit",
 		"before_update_after_submit": "time_capture.scripts.attendance.before_update_after_submit",
+		"on_change": "time_capture.scripts.attendance.on_change",
 		"on_cancel": "time_capture.scripts.attendance.on_cancel",
 	},
 	"Employee": {

--- a/time_capture/hooks.py
+++ b/time_capture/hooks.py
@@ -139,7 +139,6 @@ after_install = "time_capture.install.after_install"
 
 doc_events = {
 	"Attendance": {
-		"on_submit": "time_capture.scripts.attendance.on_submit",
 		"on_change": "time_capture.scripts.attendance.on_change",
 		"on_cancel": "time_capture.scripts.attendance.on_cancel",
 	},

--- a/time_capture/patches.txt
+++ b/time_capture/patches.txt
@@ -8,3 +8,4 @@ execute:from time_capture.install import _make_property_setters;_make_property_s
 time_capture.patches.move_expected_working_time_to_child_table
 time_capture.patches.create_freelancer_role #7
 time_capture.patches.rectify_attendance_metrics
+time_capture.patches.delete_outdated_time_captures

--- a/time_capture/patches.txt
+++ b/time_capture/patches.txt
@@ -7,3 +7,4 @@ execute:from time_capture.install import _make_custom_fields;_make_custom_fields
 execute:from time_capture.install import _make_property_setters;_make_property_setters() # 2025-09-26
 time_capture.patches.move_expected_working_time_to_child_table
 time_capture.patches.create_freelancer_role #7
+time_capture.patches.rectify_attendance_metrics

--- a/time_capture/patches/delete_outdated_time_captures.py
+++ b/time_capture/patches/delete_outdated_time_captures.py
@@ -14,7 +14,7 @@ def execute():
 			"docstatus": 1,
 			"custom_time_capture": ["!=", None],
 			"leave_type": ["!=", None],
-			"attendance_date": ("<=", frappe.utils.nowdate()),
+			"attendance_date": ("<=", frappe.utils.getdate()),
 		},
 		pluck="name",
 	)

--- a/time_capture/patches/delete_outdated_time_captures.py
+++ b/time_capture/patches/delete_outdated_time_captures.py
@@ -1,0 +1,21 @@
+import frappe
+from time_capture.scripts.attendance import delete_time_capture
+
+
+def execute():
+	"""
+	Deletes Time Captures that are not needed anymore.
+	Reason: They have been outdated by leave days.
+	"""
+	leave_days = frappe.db.get_all(
+		"Attendance",
+		filters={
+			"docstatus": 1,
+			"custom_time_capture": ["!=", None],
+			"leave_type": ["!=", None],
+			"attendance_date": ("<=", frappe.utils.nowdate()),
+		},
+		pluck="name",
+	)
+	for attendance_name in leave_days:
+		delete_time_capture(frappe.get_doc("Attendance", attendance_name))

--- a/time_capture/patches/delete_outdated_time_captures.py
+++ b/time_capture/patches/delete_outdated_time_captures.py
@@ -1,4 +1,5 @@
 import frappe
+
 from time_capture.scripts.attendance import delete_time_capture
 
 

--- a/time_capture/patches/rectify_attendance_metrics.py
+++ b/time_capture/patches/rectify_attendance_metrics.py
@@ -1,0 +1,19 @@
+import frappe
+
+from time_capture.scripts.attendance import _calculate_attendance_metrics
+
+
+def execute():
+	attendances = frappe.get_all("Attendance", filters={"docstatus": 1})
+	for attendance in attendances:
+		doc = frappe.get_doc("Attendance", attendance.name)
+		working_hours, expected_working_hours, flexitime = _calculate_attendance_metrics(doc)
+		frappe.db.set_value(
+			"Attendance",
+			doc.name,
+			{
+				"working_hours": working_hours,
+				"expected_working_hours": expected_working_hours,
+				"flexitime": flexitime,
+			},
+		)

--- a/time_capture/scripts/attendance.py
+++ b/time_capture/scripts/attendance.py
@@ -6,7 +6,7 @@ from time_capture.time_capture.doctype.time_capture.time_capture import _create_
 
 
 def on_submit(doc, event):
-	if doc.leave_type and doc.attendance_date <= frappe.utils.nowdate():
+	if doc.leave_type and doc.attendance_date <= frappe.utils.getdate():
 		delete_time_capture(doc)
 
 
@@ -14,7 +14,7 @@ def on_change(doc, event):
 	set_attendance_metrics(doc)
 	if not doc.leave_type:
 		doc.status = _get_attendance_status(doc.expected_working_hours, doc.working_hours)
-	if doc.leave_type and doc.attendance_date <= frappe.utils.nowdate():
+	if doc.leave_type and doc.attendance_date <= frappe.utils.getdate():
 		delete_time_capture(doc)
 
 

--- a/time_capture/scripts/attendance.py
+++ b/time_capture/scripts/attendance.py
@@ -21,6 +21,11 @@ def before_update_after_submit(doc, event):
 			doc.status = _get_attendance_status(doc.expected_working_hours, doc.working_hours)
 
 
+def on_change(doc, event):
+	if doc.status == "On Leave" and not doc.half_day_status:
+		delete_time_capture(doc)
+
+
 def on_cancel(doc, event):
 	employee = frappe.get_doc("Employee", doc.employee)
 	_create_time_capture(employee, doc.attendance_date)

--- a/time_capture/scripts/attendance.py
+++ b/time_capture/scripts/attendance.py
@@ -5,8 +5,6 @@ from time_capture.scripts.employee import get_expected_working_hours
 from time_capture.time_capture.doctype.time_capture.time_capture import _create_time_capture
 
 
-def on_submit(doc, event):
-	pass
 def on_change(doc, event):
 	set_attendance_metrics(doc)
 	if not doc.leave_type:

--- a/time_capture/scripts/attendance.py
+++ b/time_capture/scripts/attendance.py
@@ -5,23 +5,15 @@ from time_capture.scripts.employee import get_expected_working_hours
 from time_capture.time_capture.doctype.time_capture.time_capture import _create_time_capture
 
 
-def before_insert(doc, event):
-	set_attendance_metrics(doc)
-
-
 def on_submit(doc, event):
 	if doc.leave_type and doc.attendance_date <= frappe.utils.nowdate():
 		delete_time_capture(doc)
 
 
-def before_update_after_submit(doc, event):
-	if doc.has_value_changed("working_hours"):
-		doc.flexitime = doc.working_hours - doc.expected_working_hours
-		if not doc.leave_type:
-			doc.status = _get_attendance_status(doc.expected_working_hours, doc.working_hours)
-
-
 def on_change(doc, event):
+	set_attendance_metrics(doc)
+	if not doc.leave_type:
+		doc.status = _get_attendance_status(doc.expected_working_hours, doc.working_hours)
 	if doc.status == "On Leave" and not doc.half_day_status:
 		delete_time_capture(doc)
 

--- a/time_capture/scripts/attendance.py
+++ b/time_capture/scripts/attendance.py
@@ -6,10 +6,7 @@ from time_capture.time_capture.doctype.time_capture.time_capture import _create_
 
 
 def on_submit(doc, event):
-	if doc.leave_type and doc.attendance_date <= frappe.utils.getdate():
-		delete_time_capture(doc)
-
-
+	pass
 def on_change(doc, event):
 	set_attendance_metrics(doc)
 	if not doc.leave_type:

--- a/time_capture/scripts/attendance.py
+++ b/time_capture/scripts/attendance.py
@@ -14,7 +14,7 @@ def on_change(doc, event):
 	set_attendance_metrics(doc)
 	if not doc.leave_type:
 		doc.status = _get_attendance_status(doc.expected_working_hours, doc.working_hours)
-	if doc.status == "On Leave" and not doc.half_day_status:
+	if doc.leave_type and doc.attendance_date <= frappe.utils.nowdate():
 		delete_time_capture(doc)
 
 

--- a/time_capture/time_capture/doctype/time_capture/time_capture.py
+++ b/time_capture/time_capture/doctype/time_capture/time_capture.py
@@ -73,6 +73,9 @@ class TimeCapture(Document):
 		self.create_attendance()
 		create_timesheets(self)
 
+	def on_trash(self):
+		frappe.db.set_value("Attendance", {"custom_time_capture": self.name}, "custom_time_capture", None)
+
 	def validate_working_and_project_time(self):
 		if self.unallocated_time > 0:
 			frappe.throw(_("Working time must be completely booked on projects and tasks."))


### PR DESCRIPTION
## Context
https://github.com/alyf-de/time_capture/issues/36

## Details

on_change hook is now used to cover every case that is relevant for the metrics in Attendance. Therefore, the other hooks are removed.