### PR TITLE
fix: don't delete newly created Time Captures

### DIFF
--- a/time_capture/scripts/attendance.py
+++ b/time_capture/scripts/attendance.py
@@ -9,7 +9,11 @@ def on_change(doc, event):
 	set_attendance_metrics(doc)
 	if not doc.leave_type:
 		doc.status = _get_attendance_status(doc.expected_working_hours, doc.working_hours)
-	if doc.leave_type and frappe.utils.getdate(doc.attendance_date) <= frappe.utils.getdate():
+	if (
+		doc.leave_type
+		and frappe.utils.getdate(doc.attendance_date) <= frappe.utils.getdate()
+		and doc.docstatus != 2
+	):
 		delete_time_capture(doc)
 
 

--- a/time_capture/time_capture/doctype/time_capture/time_capture.py
+++ b/time_capture/time_capture/doctype/time_capture/time_capture.py
@@ -305,7 +305,6 @@ def _create_time_capture(employee, date):
 	time_capture = frappe.new_doc("Time Capture")
 	time_capture.update(
 		{
-			"doctype": "Time Capture",
 			"employee": employee.name,
 			"date": date,
 			"check_in": "00:00",

--- a/time_capture/time_capture/doctype/time_capture/time_capture.py
+++ b/time_capture/time_capture/doctype/time_capture/time_capture.py
@@ -48,9 +48,6 @@ class TimeCapture(Document):
 		working_time: DF.Duration | None
 
 	# end: auto-generated types
-	def before_insert(self):
-		self.is_of_legal_age = self._get_is_of_legal_age()
-
 	def before_validate(self):
 		avoid_duplicate_entries(self)
 		assure_duration_format(self)


### PR DESCRIPTION

This PR includes:

> fix: don't delete newly created **Time Captures** -> The delete_time_capture method is (after today's PR #37) run on_change. That also included cancellation. Therefore a new condition was inserted, such that the **Time Captures** will not be deleted anymore on cancellation.

And two small commits:

- Remove: redundant trigger for legal age query (before_validate already does the full job, before_insert was removed)
- small refactor