### PR TITLE
feat(Employee): update expected working hours via dialog

### DIFF
--- a/time_capture/custom_fields.py
+++ b/time_capture/custom_fields.py
@@ -42,15 +42,14 @@ def get_custom_fields():
 				"label": _("Expected Working Hours"),
 				"reqd": 1,
 				"options": "Employee Expected Working Hours",
+				"read_only_depends_on": "eval:!doc.__islocal;",
 			},
 			{
-				"fieldname": "custom_update_attendances",
+				"fieldname": "custom_change_expected_hours",
 				"fieldtype": "Button",
-				"label": _("Update Attendances"),
+				"label": _("Change/Add Expected Hours"),
 				"insert_after": "expected_working_hours",
-				"description": _(
-					"Update all Attendances with Expected Working Hours table. Only for System Manager."
-				),
+				"depends_on": "eval:!doc.__islocal;",
 			},
 			{
 				"label": _("Leave Policy"),

--- a/time_capture/locale/de.po
+++ b/time_capture/locale/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Time Capture VERSION\n"
 "Report-Msgid-Bugs-To: patrick@alyf.de\n"
-"POT-Creation-Date: 2025-12-19 10:04+0053\n"
+"POT-Creation-Date: 2025-12-19 11:02+0053\n"
 "PO-Revision-Date: 2025-11-07 14:07+0053\n"
 "Last-Translator: patrick@alyf.de\n"
 "Language-Team: patrick@alyf.de\n"
@@ -40,6 +40,10 @@ msgstr "Zusätzliche Pause"
 msgid "April"
 msgstr "April"
 
+#: time_capture/public/js/employee.js:56
+msgid "At least one Expected Working Hours entry is required."
+msgstr "Mindestens ein Eintrag in Erwartete Arbeitsstunden ist Pflicht."
+
 #. Linked DocType in Time Capture's connections
 #: time_capture/time_capture/doctype/time_capture/time_capture.json
 msgid "Attendance"
@@ -53,6 +57,10 @@ msgstr "August"
 #: time_capture/time_capture/doctype/time_capture/time_capture.json
 msgid "Break"
 msgstr "Pause"
+
+#: time_capture/custom_fields.py:50 time_capture/public/js/employee.js:29
+msgid "Change/Add Expected Hours"
+msgstr "Erwartete Stunden ändern/hinzufügen"
 
 #. Label of a Time field in DocType 'Freelancer Time Capture'
 #. Label of a Time field in DocType 'Time Capture'
@@ -94,10 +102,6 @@ msgstr "Freelancer-Benutzer wird erstellt"
 #: time_capture/time_capture/report/working_time_summary/working_time_summary.py:72
 msgid "Current Balance"
 msgstr "Aktuelles Saldo"
-
-#: time_capture/scripts/employee.py:27
-msgid "Date of Joining is not the same as the earliest date of Expected Working Hours."
-msgstr "Eintrittsdatum entspricht nicht dem frühesten Datum der erwarteten Arbeitsstunden."
 
 #: time_capture/time_capture/report/working_time/working_time.js:32
 msgid "December"
@@ -168,6 +172,7 @@ msgid "Expected Daily Working Hours"
 msgstr "Erwartete tägliche Arbeitsstunden"
 
 #: time_capture/custom_fields.py:11 time_capture/custom_fields.py:42
+#: time_capture/public/js/employee.js:35
 #: time_capture/time_capture/report/working_time/working_time.py:30
 msgid "Expected Working Hours"
 msgstr "Erwartete Arbeitsstunden"
@@ -215,7 +220,7 @@ msgid "Freelancer Name"
 msgstr "Freelancer-Name"
 
 #. Name of a DocType
-#: time_capture/custom_fields.py:92
+#: time_capture/custom_fields.py:91
 #: time_capture/time_capture/doctype/freelancer_time_capture/freelancer_time_capture.json
 msgid "Freelancer Time Capture"
 msgstr "Freelancer Zeiterfassung"
@@ -224,7 +229,7 @@ msgstr "Freelancer Zeiterfassung"
 msgid "Freelancer Time Capture can only be created for users with the 'Freelancer' role. Change the user in the field 'User'."
 msgstr "Freelancer Zeiterfassung kann nur für Benutzer mit der 'Freelancer'-Rolle erstellt werden. Ändern Sie den Benutzer im Feld 'Benutzer'."
 
-#: time_capture/custom_fields.py:100
+#: time_capture/custom_fields.py:99
 msgid "Freelancer User"
 msgstr "Freelancer-Benutzer"
 
@@ -301,7 +306,7 @@ msgstr "Letzte manuelle Saldo-Korrektur"
 msgid "Last Notification (Sent On)"
 msgstr "Letzte Benachrichtigung (gesendet am)"
 
-#: time_capture/custom_fields.py:56
+#: time_capture/custom_fields.py:55
 msgid "Leave Policy"
 msgstr "Urlaubsrichtlinie"
 
@@ -414,9 +419,9 @@ msgstr "November"
 msgid "October"
 msgstr "Oktober"
 
-#: time_capture/scripts/employee.py:92
-msgid "Only System Manager are allowed to update Attendances with Expected Working Hours."
-msgstr "Nur System Manager sind berechtigt, Attendances mit erwarteten Arbeitsstunden zu aktualisieren."
+#: time_capture/public/js/employee.js:11
+msgid "Only System Manager are allowed to edit Expected Working Hours."
+msgstr "Nur System Manager dürgen Erwartete Arbeitsstunden anpassen."
 
 #. Description of the 'Minimum Draft Age (Days)' (Int) field in DocType 'Time
 #. Capture Settings'
@@ -457,6 +462,10 @@ msgstr "Geplante Überstundenreduzierung"
 msgid "Please review and submit the pending Time Captures."
 msgstr "Bitte überprüfen und buchen Sie die ausstehenden Zeiterfassungen."
 
+#: time_capture/public/js/employee.js:5
+msgid "Please save the Employee first."
+msgstr "Bitte speichern Sie den Mitarbeiter zuerst."
+
 #: time_capture/time_capture/doctype/create_freelancer/create_freelancer.js:18
 msgid "Please wait..."
 msgstr "Bitte warten..."
@@ -481,6 +490,10 @@ msgstr "Erinnerung: Sie haben ungebuchte Zeiterfassungen"
 #: time_capture/time_capture/time_capture_controller.py:34
 msgid "Row {0}: Duration is not in the proper format."
 msgstr "Zeile {0}: Dauer ist nicht im korrekten Format."
+
+#: time_capture/public/js/employee.js:82
+msgid "Save & Update Attendances"
+msgstr "Speichern & Anwesenheiten aktualisieren"
 
 #: time_capture/time_capture/report/working_time/working_time.js:29
 msgid "September"
@@ -513,6 +526,10 @@ msgstr "Summe für {}"
 msgid "Task {0} does not belong to Project {1}"
 msgstr "Vorgang {0} gehört nicht zu Projekt {1}"
 
+#: time_capture/scripts/employee.py:27
+msgid "The date of joining ({0}) has to be the earliest date of Expected Working Hours."
+msgstr "Das Beitrittsdatum muss dem frühesten Datum in Erwartete Arbeitsstunden entsprechen."
+
 #: time_capture/templates/time_capture_reminder.html:4
 msgid "The following Time Captures are still in draft status:"
 msgstr "Die folgenden Zeiterfassungen sind noch im Entwurfsstatus:"
@@ -530,12 +547,12 @@ msgid "This is the projected balance, that includes planned overtime reductions"
 msgstr "Dies ist das prognostizierte Saldo, das geplante Überstundenreduzierungen enthält"
 
 #. Name of a DocType
-#: time_capture/custom_fields.py:28 time_capture/custom_fields.py:84
+#: time_capture/custom_fields.py:28 time_capture/custom_fields.py:83
 #: time_capture/time_capture/doctype/time_capture/time_capture.json
 msgid "Time Capture"
 msgstr "Zeiterfassung"
 
-#: time_capture/public/js/employee.js:13
+#: time_capture/public/js/employee.js:91
 msgid "Time Capture & Leave Summary"
 msgstr "Zeiterfassungs- & Urlaubsübersicht"
 
@@ -575,14 +592,6 @@ msgstr "Zusammenfassungsdaten konnten nicht abgerufen werden"
 msgid "Unallocated Time"
 msgstr "Nicht zugewiesene Zeit"
 
-#: time_capture/custom_fields.py:49
-msgid "Update Attendances"
-msgstr "Anwesenheiten aktualisieren"
-
-#: time_capture/custom_fields.py:51
-msgid "Update all Attendances with Expected Working Hours table. Only for System Manager."
-msgstr "Aktualisiere alle Anwesenheiten mit der Tabelle erwarteter Arbeitsstunden. Nur für System Manager."
-
 #. Description of the 'Standard Email Recipient' (Data) field in DocType 'Time
 #. Capture Settings'
 #: time_capture/time_capture/doctype/time_capture_settings/time_capture_settings.json
@@ -619,7 +628,7 @@ msgstr "Die Arbeitszeit muss vollständig auf Projekte und Aufgaben gebucht werd
 msgid "{0} (on {1})"
 msgstr "{0} (am {1})"
 
-#: time_capture/scripts/employee.py:113
+#: time_capture/public/js/employee.js:72 time_capture/scripts/employee.py:141
 msgid "{0} Attendances updated successfully."
 msgstr "{0} Attendances erfolgreich aktualisiert."
 

--- a/time_capture/locale/de.po
+++ b/time_capture/locale/de.po
@@ -421,7 +421,7 @@ msgstr "Oktober"
 
 #: time_capture/public/js/employee.js:11
 msgid "Only System Manager are allowed to edit Expected Working Hours."
-msgstr "Nur System Manager dürgen Erwartete Arbeitsstunden anpassen."
+msgstr "Nur System Manager dürfen Erwartete Arbeitsstunden anpassen."
 
 #. Description of the 'Minimum Draft Age (Days)' (Int) field in DocType 'Time
 #. Capture Settings'

--- a/time_capture/locale/main.pot
+++ b/time_capture/locale/main.pot
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Time Capture VERSION\n"
 "Report-Msgid-Bugs-To: patrick@alyf.de\n"
-"POT-Creation-Date: 2025-12-19 10:04+0053\n"
-"PO-Revision-Date: 2025-12-19 10:04+0053\n"
+"POT-Creation-Date: 2025-12-19 11:02+0053\n"
+"PO-Revision-Date: 2025-12-19 11:02+0053\n"
 "Last-Translator: patrick@alyf.de\n"
 "Language-Team: patrick@alyf.de\n"
 "MIME-Version: 1.0\n"
@@ -40,6 +40,10 @@ msgstr ""
 msgid "April"
 msgstr ""
 
+#: time_capture/public/js/employee.js:56
+msgid "At least one Expected Working Hours entry is required."
+msgstr ""
+
 #. Linked DocType in Time Capture's connections
 #: time_capture/time_capture/doctype/time_capture/time_capture.json
 msgid "Attendance"
@@ -52,6 +56,10 @@ msgstr ""
 #. Label of a Duration field in DocType 'Time Capture'
 #: time_capture/time_capture/doctype/time_capture/time_capture.json
 msgid "Break"
+msgstr ""
+
+#: time_capture/custom_fields.py:50 time_capture/public/js/employee.js:29
+msgid "Change/Add Expected Hours"
 msgstr ""
 
 #. Label of a Time field in DocType 'Freelancer Time Capture'
@@ -93,10 +101,6 @@ msgstr ""
 #: time_capture/time_capture/report/leave_and_working_time_summaries/leave_and_working_time_summaries.py:75
 #: time_capture/time_capture/report/working_time_summary/working_time_summary.py:72
 msgid "Current Balance"
-msgstr ""
-
-#: time_capture/scripts/employee.py:27
-msgid "Date of Joining is not the same as the earliest date of Expected Working Hours."
 msgstr ""
 
 #: time_capture/time_capture/report/working_time/working_time.js:32
@@ -168,6 +172,7 @@ msgid "Expected Daily Working Hours"
 msgstr ""
 
 #: time_capture/custom_fields.py:11 time_capture/custom_fields.py:42
+#: time_capture/public/js/employee.js:35
 #: time_capture/time_capture/report/working_time/working_time.py:30
 msgid "Expected Working Hours"
 msgstr ""
@@ -215,7 +220,7 @@ msgid "Freelancer Name"
 msgstr ""
 
 #. Name of a DocType
-#: time_capture/custom_fields.py:92
+#: time_capture/custom_fields.py:91
 #: time_capture/time_capture/doctype/freelancer_time_capture/freelancer_time_capture.json
 msgid "Freelancer Time Capture"
 msgstr ""
@@ -224,7 +229,7 @@ msgstr ""
 msgid "Freelancer Time Capture can only be created for users with the 'Freelancer' role. Change the user in the field 'User'."
 msgstr ""
 
-#: time_capture/custom_fields.py:100
+#: time_capture/custom_fields.py:99
 msgid "Freelancer User"
 msgstr ""
 
@@ -301,7 +306,7 @@ msgstr ""
 msgid "Last Notification (Sent On)"
 msgstr ""
 
-#: time_capture/custom_fields.py:56
+#: time_capture/custom_fields.py:55
 msgid "Leave Policy"
 msgstr ""
 
@@ -414,8 +419,8 @@ msgstr ""
 msgid "October"
 msgstr ""
 
-#: time_capture/scripts/employee.py:92
-msgid "Only System Manager are allowed to update Attendances with Expected Working Hours."
+#: time_capture/public/js/employee.js:11
+msgid "Only System Manager are allowed to edit Expected Working Hours."
 msgstr ""
 
 #. Description of the 'Minimum Draft Age (Days)' (Int) field in DocType 'Time
@@ -457,6 +462,10 @@ msgstr ""
 msgid "Please review and submit the pending Time Captures."
 msgstr ""
 
+#: time_capture/public/js/employee.js:5
+msgid "Please save the Employee first."
+msgstr ""
+
 #: time_capture/time_capture/doctype/create_freelancer/create_freelancer.js:18
 msgid "Please wait..."
 msgstr ""
@@ -480,6 +489,10 @@ msgstr ""
 
 #: time_capture/time_capture/time_capture_controller.py:34
 msgid "Row {0}: Duration is not in the proper format."
+msgstr ""
+
+#: time_capture/public/js/employee.js:82
+msgid "Save & Update Attendances"
 msgstr ""
 
 #: time_capture/time_capture/report/working_time/working_time.js:29
@@ -513,6 +526,10 @@ msgstr ""
 msgid "Task {0} does not belong to Project {1}"
 msgstr ""
 
+#: time_capture/scripts/employee.py:27
+msgid "The date of joining ({0}) has to be the earliest date of Expected Working Hours."
+msgstr ""
+
 #: time_capture/templates/time_capture_reminder.html:4
 msgid "The following Time Captures are still in draft status:"
 msgstr ""
@@ -530,12 +547,12 @@ msgid "This is the projected balance, that includes planned overtime reductions"
 msgstr ""
 
 #. Name of a DocType
-#: time_capture/custom_fields.py:28 time_capture/custom_fields.py:84
+#: time_capture/custom_fields.py:28 time_capture/custom_fields.py:83
 #: time_capture/time_capture/doctype/time_capture/time_capture.json
 msgid "Time Capture"
 msgstr ""
 
-#: time_capture/public/js/employee.js:13
+#: time_capture/public/js/employee.js:91
 msgid "Time Capture & Leave Summary"
 msgstr ""
 
@@ -575,14 +592,6 @@ msgstr ""
 msgid "Unallocated Time"
 msgstr ""
 
-#: time_capture/custom_fields.py:49
-msgid "Update Attendances"
-msgstr ""
-
-#: time_capture/custom_fields.py:51
-msgid "Update all Attendances with Expected Working Hours table. Only for System Manager."
-msgstr ""
-
 #. Description of the 'Standard Email Recipient' (Data) field in DocType 'Time
 #. Capture Settings'
 #: time_capture/time_capture/doctype/time_capture_settings/time_capture_settings.json
@@ -619,7 +628,7 @@ msgstr ""
 msgid "{0} (on {1})"
 msgstr ""
 
-#: time_capture/scripts/employee.py:113
+#: time_capture/public/js/employee.js:72 time_capture/scripts/employee.py:141
 msgid "{0} Attendances updated successfully."
 msgstr ""
 

--- a/time_capture/patches.txt
+++ b/time_capture/patches.txt
@@ -11,3 +11,4 @@ time_capture.patches.rectify_attendance_metrics
 time_capture.patches.delete_outdated_time_captures
 execute:frappe.db.set_value("Freelancer Time Capture", {"docstatus": ["!=", 0]}, {"check_in": "00:00", "check_out": "00:00"})
 execute:frappe.db.delete("Custom Field", {"name": "Employee-custom_update_attendances"})
+time_capture.patches.rectify_attendance_metrics_2512

--- a/time_capture/patches.txt
+++ b/time_capture/patches.txt
@@ -3,10 +3,11 @@
 # Read docs to understand patches: https://frappeframework.com/docs/v14/user/en/database-migrations
 
 [post_model_sync]
-execute:from time_capture.install import _make_custom_fields;_make_custom_fields() # 2025-08-04 #1
+execute:from time_capture.install import _make_custom_fields;_make_custom_fields() # 2025-12-19 #2
 execute:from time_capture.install import _make_property_setters;_make_property_setters() # 2025-09-26
 time_capture.patches.move_expected_working_time_to_child_table
 time_capture.patches.create_freelancer_role #7
 time_capture.patches.rectify_attendance_metrics
 time_capture.patches.delete_outdated_time_captures
 execute:frappe.db.set_value("Freelancer Time Capture", {"docstatus": ["!=", 0]}, {"check_in": "00:00", "check_out": "00:00"})
+execute:frappe.db.delete("Custom Field", {"name": "Employee-custom_update_attendances"})

--- a/time_capture/patches/rectify_attendance_metrics_2512.py
+++ b/time_capture/patches/rectify_attendance_metrics_2512.py
@@ -1,0 +1,9 @@
+import frappe
+
+from time_capture.scripts.employee import update_attendances_for_employee
+
+
+def execute():
+	employees = frappe.get_all("Employee", filters={"status": "Active"})
+	for employee in employees:
+		update_attendances_for_employee(employee.name)

--- a/time_capture/public/js/employee.js
+++ b/time_capture/public/js/employee.js
@@ -1,11 +1,89 @@
 frappe.ui.form.on("Employee", {
-	custom_update_attendances: function (frm) {
-		frappe.call(
-			"time_capture.scripts.employee.update_attendances_with_expected_working_hours",
-			{
-				employee_id: frm.doc.name,
-			}
-		);
+	custom_change_expected_hours: function (frm) {
+		// Check if the employee is local or dirty.
+		if (frm.doc.__islocal || frm.is_dirty()) {
+			frappe.msgprint(__("Please save the Employee first."));
+			return;
+		}
+
+		// only allow "System Manager" role to edit.
+		if (!frappe.user_roles.includes("System Manager")) {
+			frappe.msgprint(__("Only System Manager are allowed to edit Expected Working Hours."));
+			return;
+		}
+
+		// Get current expected working hours data
+		const current_data = (frm.doc.expected_working_hours || []).map((row) => {
+			return {
+				valid_from: row.valid_from,
+				expected_daily_working_hours: row.expected_daily_working_hours,
+			};
+		});
+
+		// Get child table fields
+		frappe.model.with_doctype("Employee Expected Working Hours", () => {
+			const child_fields = frappe.meta.get_docfields("Employee Expected Working Hours");
+
+			// Create dialog
+			const dialog = new frappe.ui.Dialog({
+				title: __("Change/Add Expected Hours"),
+				size: "large",
+				fields: [
+					{
+						fieldname: "expected_working_hours",
+						fieldtype: "Table",
+						label: __("Expected Working Hours"),
+						reqd: 1,
+						data: current_data,
+						get_data: () => {
+							return current_data;
+						},
+						fields: child_fields.filter((df) => {
+							return (
+								!frappe.model.no_value_type.includes(df.fieldtype) &&
+								!df.hidden &&
+								df.fieldname !== "name"
+							);
+						}),
+					},
+				],
+				primary_action: function () {
+					const values = this.get_values();
+					const expected_working_hours = values.expected_working_hours || [];
+
+					if (expected_working_hours.length === 0) {
+						frappe.msgprint(
+							__("At least one Expected Working Hours entry is required.")
+						);
+						return;
+					}
+
+					const dialog_ref = this;
+					frappe.call({
+						method: "time_capture.scripts.employee.save_expected_working_hours_and_update_attendances",
+						freeze: true,
+						args: {
+							employee_id: frm.doc.name,
+							expected_working_hours: expected_working_hours,
+						},
+						callback: function (r) {
+							if (r.message) {
+								frappe.msgprint(
+									__("{0} Attendances updated successfully.", [
+										r.message.updated_count,
+									])
+								);
+							}
+							frm.reload_doc();
+							dialog_ref.hide();
+						},
+					});
+				},
+				primary_action_label: __("Save & Update Attendances"),
+			});
+
+			dialog.show();
+		});
 	},
 
 	onload: function (frm) {

--- a/time_capture/public/js/employee.js
+++ b/time_capture/public/js/employee.js
@@ -67,13 +67,6 @@ frappe.ui.form.on("Employee", {
 							expected_working_hours: expected_working_hours,
 						},
 						callback: function (r) {
-							if (r.message) {
-								frappe.msgprint(
-									__("{0} Attendances updated successfully.", [
-										r.message.updated_count,
-									])
-								);
-							}
 							frm.reload_doc();
 							dialog_ref.hide();
 						},

--- a/time_capture/scripts/employee.py
+++ b/time_capture/scripts/employee.py
@@ -85,11 +85,36 @@ def get_expected_working_hours(employee_id, date):
 
 
 @frappe.whitelist()
-def update_attendances_with_expected_working_hours(employee_id):
-	from time_capture.scripts.attendance import _calculate_attendance_metrics
+def save_expected_working_hours_and_update_attendances(employee_id, expected_working_hours):
+	"""
+	Save expected working hours to employee and update all attendances.
+	"""
+	frappe.has_permission(doctype="Employee", doc=employee_id, ptype="write", throw=True)
 
-	if "System Manager" not in frappe.get_roles():
-		frappe.throw(_("Only System Manager are allowed to update Attendances with Expected Working Hours."))
+	# Load doc and clear existing expected working hours
+	employee = frappe.get_doc("Employee", employee_id)
+	employee.expected_working_hours = []
+
+	# Add new expected working hours
+	for ewh_data in expected_working_hours:
+		employee.append(
+			"expected_working_hours",
+			{
+				"valid_from": ewh_data.get("valid_from"),
+				"expected_daily_working_hours": ewh_data.get("expected_daily_working_hours"),
+			},
+		)
+
+	# Save employee document (this will trigger validation) and update attendances
+	employee.save()
+	update_attendances_for_employee(employee_id)
+
+
+def update_attendances_for_employee(employee_id):
+	"""
+	Update all attendances for an employee by recalculating the attendance metrics.
+	"""
+	from time_capture.scripts.attendance import _calculate_attendance_metrics
 
 	attendances_to_update = frappe.get_all(
 		"Attendance",

--- a/time_capture/scripts/employee.py
+++ b/time_capture/scripts/employee.py
@@ -24,7 +24,11 @@ def before_validate(doc, method):
 
 def validate_expected_working_hours(doc):
 	if not getdate(doc.date_of_joining) == min(getdate(ewh.valid_from) for ewh in doc.expected_working_hours):
-		frappe.throw(_("Date of Joining is not the same as the earliest date of Expected Working Hours."))
+		frappe.throw(
+			_("The date of joining ({0}) has to be the earliest date of Expected Working Hours.").format(
+				frappe.utils.format_date(doc.date_of_joining)
+			)
+		)
 
 
 def create_leave_policy_assignment(doc):
@@ -94,6 +98,9 @@ def save_expected_working_hours_and_update_attendances(employee_id, expected_wor
 	# Load doc and clear existing expected working hours
 	employee = frappe.get_doc("Employee", employee_id)
 	employee.expected_working_hours = []
+
+	# turn expected_working_hours from string to a list of dicts
+	expected_working_hours = frappe.parse_json(expected_working_hours)
 
 	# Add new expected working hours
 	for ewh_data in expected_working_hours:


### PR DESCRIPTION
CASE: 
When the Expected Working Hours are changed in DocType Employee. 

PROBLEM:
Refresh Button has to be pressed, otherwise the Attendances are not updated.
This might lead to data inconsistency, as there might be changes that are not synced to Attendances, because the button was not pressed.

SOLUTION:
The „Update Attendance“ shall be removed. 
Instead: 
- Add a button (new field) „Change/Add Expected Hours“
- This button opens a dialog where the child table can be edited.
- After submitting the dialog, all Attendances are updated.

DETAILS:
- In form view the table should then be read only.
- This is only necessary if the employee is not yet inserted. Otherwise the table can just be edited in form view.
