### PR TITLE
fix(Attendance): calculation of a Attendance metrics incl. status (DRC-280)

### DIFF
--- a/time_capture/patches.txt
+++ b/time_capture/patches.txt
@@ -11,4 +11,4 @@ time_capture.patches.rectify_attendance_metrics
 time_capture.patches.delete_outdated_time_captures
 execute:frappe.db.set_value("Freelancer Time Capture", {"docstatus": ["!=", 0]}, {"check_in": "00:00", "check_out": "00:00"})
 execute:frappe.db.delete("Custom Field", {"name": "Employee-custom_update_attendances"})
-time_capture.patches.rectify_attendance_metrics_2512
+time_capture.patches.rectify_attendance_metrics_2512 # 2026-01-12

--- a/time_capture/patches/rectify_attendance_metrics.py
+++ b/time_capture/patches/rectify_attendance_metrics.py
@@ -1,17 +1,18 @@
 import frappe
 
-from time_capture.scripts.attendance import _calculate_attendance_metrics
+from time_capture.scripts.attendance import get_attendance_metrics
 
 
 def execute():
 	attendances = frappe.get_all("Attendance", filters={"docstatus": 1})
 	for attendance in attendances:
 		doc = frappe.get_doc("Attendance", attendance.name)
-		working_hours, expected_working_hours, flexitime = _calculate_attendance_metrics(doc)
+		status, working_hours, expected_working_hours, flexitime = get_attendance_metrics(doc)
 		frappe.db.set_value(
 			"Attendance",
 			doc.name,
 			{
+				"status": status,
 				"working_hours": working_hours,
 				"expected_working_hours": expected_working_hours,
 				"flexitime": flexitime,

--- a/time_capture/patches/rectify_attendance_metrics_2512.py
+++ b/time_capture/patches/rectify_attendance_metrics_2512.py
@@ -4,6 +4,6 @@ from time_capture.scripts.employee import update_attendances_for_employee
 
 
 def execute():
-	employees = frappe.get_all("Employee", filters={"status": "Active"})
+	employees = frappe.get_all("Employee")
 	for employee in employees:
 		update_attendances_for_employee(employee.name)

--- a/time_capture/scripts/attendance.py
+++ b/time_capture/scripts/attendance.py
@@ -7,8 +7,6 @@ from time_capture.time_capture.doctype.time_capture.time_capture import _create_
 
 def on_change(doc, event):
 	set_attendance_metrics(doc)
-	if not doc.leave_type:
-		doc.status = _get_attendance_status(doc.expected_working_hours, doc.working_hours)
 	if (
 		doc.leave_type
 		and frappe.utils.getdate(doc.attendance_date) <= frappe.utils.getdate()
@@ -23,13 +21,14 @@ def on_cancel(doc, event):
 
 
 def set_attendance_metrics(doc):
-	working_hours, expected_working_hours, flexitime = _calculate_attendance_metrics(doc)
+	status, working_hours, expected_working_hours, flexitime = get_attendance_metrics(doc)
 	if doc.flags.after_submit:
 		# This is needed if a late Time Capture is submitted and updates the Attendance metrics.
 		frappe.db.set_value(
 			"Attendance",
 			doc.name,
 			{
+				"status": status,
 				"working_hours": working_hours,
 				"expected_working_hours": expected_working_hours,
 				"flexitime": flexitime,
@@ -37,12 +36,13 @@ def set_attendance_metrics(doc):
 		)
 	else:
 		# This is the normal flow.
+		doc.status = status
 		doc.working_hours = working_hours or 0
 		doc.expected_working_hours = expected_working_hours or 0
 		doc.flexitime = flexitime or 0
 
 
-def _calculate_attendance_metrics(doc, update_from_employee: bool = False):
+def get_attendance_metrics(doc):
 	"""
 	Calculates actual working hours, expected working hours, and flexitime
 	based on the attendance document. Also sets the attendance status.
@@ -51,27 +51,29 @@ def _calculate_attendance_metrics(doc, update_from_employee: bool = False):
 	Returns:
 	        tuple: (actual_working_hours, expected_working_hours, flexitime)
 	"""
-	expected_working_hours_full_day = get_expected_working_hours(doc.employee, doc.attendance_date)
+	expected_working_hours_full_day = get_expected_working_hours(doc.employee, doc.attendance_date) or 0.0
+	status = _get_attendance_status(doc.leave_type, expected_working_hours_full_day, doc.working_hours)
 
-	# Handle Leaves
 	if doc.leave_type:
-		if frappe.db.get_value("Leave Type", doc.leave_type, "is_compensatory"):
-			return 0.0, 0.0, -expected_working_hours_full_day
-		else:
-			return 0.0, 0.0, 0.0
+		working_hours = 0.0
+		expected_working_hours = 0.0
+		flexitime = (
+			0.0
+			if not frappe.db.get_value("Leave Type", doc.leave_type, "is_compensatory")
+			else -expected_working_hours_full_day
+		)
+	else:
+		working_hours = doc.working_hours
+		expected_working_hours = expected_working_hours_full_day
+		flexitime = working_hours - expected_working_hours_full_day
 
-	if expected_working_hours_full_day and not update_from_employee:
-		doc.status = _get_attendance_status(expected_working_hours_full_day, doc.working_hours)
-
-	# Normal Working Day
-	return (
-		doc.working_hours,
-		expected_working_hours_full_day,
-		doc.working_hours - expected_working_hours_full_day,
-	)
+	return status, working_hours, expected_working_hours, flexitime
 
 
-def _get_attendance_status(expected_working_hours_full_day: float, working_hours: float):
+def _get_attendance_status(leave_type: str, expected_working_hours_full_day: float, working_hours: float):
+	if leave_type:
+		return "On Leave"
+
 	if working_hours == 0:
 		return "Absent"
 

--- a/time_capture/scripts/attendance.py
+++ b/time_capture/scripts/attendance.py
@@ -47,9 +47,9 @@ def get_attendance_metrics(doc):
 	Calculates actual working hours, expected working hours, and flexitime
 	based on the attendance document. Also sets the attendance status.
 	Args:
-	        doc (frappe.model.document.Document): The attendance document.
+	                doc (frappe.model.document.Document): The attendance document.
 	Returns:
-	        tuple: (actual_working_hours, expected_working_hours, flexitime)
+	                tuple: (status, actual_working_hours, expected_working_hours, flexitime)
 	"""
 	expected_working_hours_full_day = get_expected_working_hours(doc.employee, doc.attendance_date) or 0.0
 	status = _get_attendance_status(doc.leave_type, expected_working_hours_full_day, doc.working_hours)

--- a/time_capture/scripts/attendance.py
+++ b/time_capture/scripts/attendance.py
@@ -24,9 +24,22 @@ def on_cancel(doc, event):
 
 def set_attendance_metrics(doc):
 	working_hours, expected_working_hours, flexitime = _calculate_attendance_metrics(doc)
-	doc.working_hours = working_hours or 0
-	doc.expected_working_hours = expected_working_hours or 0
-	doc.flexitime = flexitime or 0
+	if doc.flags.after_submit:
+		# This is needed if a late Time Capture is submitted and updates the Attendance metrics.
+		frappe.db.set_value(
+			"Attendance",
+			doc.name,
+			{
+				"working_hours": working_hours,
+				"expected_working_hours": expected_working_hours,
+				"flexitime": flexitime,
+			},
+		)
+	else:
+		# This is the normal flow.
+		doc.working_hours = working_hours or 0
+		doc.expected_working_hours = expected_working_hours or 0
+		doc.flexitime = flexitime or 0
 
 
 def _calculate_attendance_metrics(doc, update_from_employee: bool = False):

--- a/time_capture/scripts/attendance.py
+++ b/time_capture/scripts/attendance.py
@@ -37,9 +37,9 @@ def set_attendance_metrics(doc):
 	else:
 		# This is the normal flow.
 		doc.status = status
-		doc.working_hours = working_hours or 0
-		doc.expected_working_hours = expected_working_hours or 0
-		doc.flexitime = flexitime or 0
+		doc.working_hours = working_hours
+		doc.expected_working_hours = expected_working_hours
+		doc.flexitime = flexitime
 
 
 def get_attendance_metrics(doc):
@@ -63,7 +63,7 @@ def get_attendance_metrics(doc):
 			else -expected_working_hours_full_day
 		)
 	else:
-		working_hours = doc.working_hours
+		working_hours = doc.working_hours or 0.0
 		expected_working_hours = expected_working_hours_full_day
 		flexitime = working_hours - expected_working_hours_full_day
 

--- a/time_capture/scripts/employee.py
+++ b/time_capture/scripts/employee.py
@@ -135,7 +135,7 @@ def update_attendances_for_employee(employee_id):
 	"""
 	Update all attendances for an employee by recalculating the attendance metrics.
 	"""
-	from time_capture.scripts.attendance import _calculate_attendance_metrics
+	from time_capture.scripts.attendance import get_attendance_metrics
 
 	attendances_to_update = frappe.get_all(
 		"Attendance",
@@ -144,13 +144,12 @@ def update_attendances_for_employee(employee_id):
 	)
 	for attendance_id in attendances_to_update:
 		doc = frappe.get_doc("Attendance", attendance_id)
-		working_hours, expected_working_hours, flexitime = _calculate_attendance_metrics(
-			doc, update_from_employee=True
-		)
+		status, working_hours, expected_working_hours, flexitime = get_attendance_metrics(doc)
 		frappe.db.set_value(
 			"Attendance",
 			doc.name,
 			{
+				"status": status,
 				"working_hours": working_hours,
 				"expected_working_hours": expected_working_hours,
 				"flexitime": flexitime,

--- a/time_capture/time_capture/doctype/time_capture/time_capture.py
+++ b/time_capture/time_capture/doctype/time_capture/time_capture.py
@@ -132,6 +132,7 @@ class TimeCapture(Document):
 			attendance.working_hours = self.working_time / 60 / 60
 			attendance.custom_time_capture = self.name
 			attendance.flags.ignore_permissions = True
+			attendance.flags.after_submit = True
 			attendance.save()
 
 	def validate_time_to_submit_in_days(self):


### PR DESCRIPTION
## Problem 1: Salden-Berechnung

Die Arbeitszeitsalden wurden teilweise falsch berechnet.

### Ursache

Verspätet gebuchte **Zeiterfassungen** aktualisieren Einträge in **Anwesenheit** nicht korrekt.

### Lösung

Code robuster machen, sodass die _Flexitime_ in **Anwesenheiten** aktualisiert wird – sowohl für neue **Anwesenheiten**, als auch für verspätet gebuchte **Zeiterfassungen**.

## Problem 2: Status in Anwesenheit
Der Status wurde nicht immer korrekt gesetzt (Beispiel: "Abwesend" für **Anwesenheiten** mit voller Arbeitszeit)

### Ursache
Status wurde nicht beim Aktualisieren gesetzt.

### Lösung
Status immer setzen