### PR TITLE
fix(Attendance)!: don't expect working hours on holidays with extra work

### DIFF
--- a/time_capture/hooks.py
+++ b/time_capture/hooks.py
@@ -151,6 +151,9 @@ doc_events = {
 		"before_validate": "time_capture.scripts.employee.before_validate",
 		"validate": "time_capture.scripts.employee.validate",
 	},
+	"Holiday List": {
+		"validate": "time_capture.scripts.holiday_list.validate",
+	},
 }
 
 # Scheduled Tasks

--- a/time_capture/patches.txt
+++ b/time_capture/patches.txt
@@ -11,4 +11,4 @@ time_capture.patches.rectify_attendance_metrics
 time_capture.patches.delete_outdated_time_captures
 execute:frappe.db.set_value("Freelancer Time Capture", {"docstatus": ["!=", 0]}, {"check_in": "00:00", "check_out": "00:00"})
 execute:frappe.db.delete("Custom Field", {"name": "Employee-custom_update_attendances"})
-time_capture.patches.rectify_attendance_metrics_2512 # 2026-01-12
+time_capture.patches.rectify_attendance_metrics_2512 # 2026-01-12 #2

--- a/time_capture/scripts/employee.py
+++ b/time_capture/scripts/employee.py
@@ -5,6 +5,8 @@ from frappe.utils import getdate
 from frappe.utils.data import today
 from hrms.hr.utils import get_leave_period
 
+from time_capture.scripts.holiday_list import validate_holiday_list_period_for_employee
+
 
 def validate(doc, method=None):
 	if doc.is_new():
@@ -17,6 +19,9 @@ def validate(doc, method=None):
 		)
 		# A new feature is planned, that will regularly create new Leave Allocations for new periods.
 		# TODO: Update this message when the feature is implemented.
+	if not doc.is_new() and doc.has_value_changed("holiday_list") and doc.holiday_list:
+		from_date, to_date = frappe.db.get_value("Holiday List", doc.holiday_list, ["from_date", "to_date"])
+		validate_holiday_list_period_for_employee(doc.name, from_date, to_date)
 
 
 def before_validate(doc, method):

--- a/time_capture/scripts/employee.py
+++ b/time_capture/scripts/employee.py
@@ -1,4 +1,5 @@
 import frappe
+from erpnext.setup.doctype.employee.employee import is_holiday
 from frappe import _
 from frappe.utils import getdate
 from frappe.utils.data import today
@@ -87,10 +88,24 @@ def _show_leave_types_created_info(leave_policy):
 		)
 
 
-def get_expected_working_hours(employee_id, date):
+def get_expected_working_hours(employee_id, date, validate_active_holiday_list=True):
 	"""
 	Get the expected working hours for an employee on a specific date.
 	"""
+	date = getdate(date)
+	holiday_list = frappe.db.get_value("Employee", employee_id, "holiday_list")
+	if validate_active_holiday_list:
+		hl_from_date, hl_to_date = frappe.db.get_value("Holiday List", holiday_list, ["from_date", "to_date"])
+		if not (hl_from_date <= date <= hl_to_date):
+			frappe.throw(
+				_(
+					"The date {0} is not within the period of the active holiday list for employee {1}."
+				).format(frappe.utils.format_date(date), employee_id)
+			)
+
+	if holiday_list and is_holiday(employee=employee_id, date=date):
+		return 0.0
+
 	return (
 		frappe.db.get_value(
 			"Employee Expected Working Hours",

--- a/time_capture/scripts/holiday_list.py
+++ b/time_capture/scripts/holiday_list.py
@@ -25,16 +25,23 @@ def validate_holiday_list_period_for_employee(employee: str, from_date: str, to_
 	if not frappe.db.exists("Attendance", filters):
 		return
 
-	min_attendance_date = frappe.db.get_all(
-		"Attendance", filters=filters, order_by="attendance_date asc", limit=1, pluck="attendance_date"
-	)[0]
-	max_attendance_date = frappe.db.get_all(
-		"Attendance", filters=filters, order_by="attendance_date desc", limit=1, pluck="attendance_date"
-	)[0]
+	attendance_span = frappe.db.get_all(
+		"Attendance",
+		filters=filters,
+		fields=[
+			"MIN(attendance_date) as min_attendance_date",
+			"MAX(attendance_date) as max_attendance_date	",
+		],
+	)
+	min_attendance_date = attendance_span[0].min_attendance_date
+	max_attendance_date = attendance_span[0].max_attendance_date
 
-	if min_attendance_date <= from_date or max_attendance_date >= to_date:
-		msg = _("Employee {0} has Attendances outside the Holiday List period.").format(employee)
-		msg += "<br>" + _(
-			"Please adjust the Holiday List, such that it covers all Attendances (from {0} to {1} and possibly ongoing)."
-		).format(frappe.utils.format_date(min_attendance_date), frappe.utils.format_date(max_attendance_date))
-		frappe.throw(msg)
+	if from_date <= min_attendance_date and to_date >= max_attendance_date:
+		# All Attendances are within the Holiday List period.
+		return
+
+	msg = _("Employee {0} has Attendances outside the Holiday List period.").format(employee)
+	msg += "<br>" + _(
+		"Please adjust the Holiday List, such that it covers all Attendances (from {0} to {1} and possibly ongoing)."
+	).format(frappe.utils.format_date(min_attendance_date), frappe.utils.format_date(max_attendance_date))
+	frappe.throw(msg)

--- a/time_capture/scripts/holiday_list.py
+++ b/time_capture/scripts/holiday_list.py
@@ -1,0 +1,40 @@
+import frappe
+from frappe import _
+from frappe.utils import getdate
+
+
+def validate(doc, method=None):
+	if not doc.is_new() and (doc.has_value_changed("from_date") or doc.has_value_changed("to_date")):
+		validate_period(doc.name, doc.from_date, doc.to_date)
+
+
+def validate_period(holiday_list: str, from_date: str, to_date: str):
+	"""Validate Holiday List period for all Employees."""
+	employees = frappe.db.get_all("Employee", filters={"holiday_list": holiday_list}, pluck="name")
+	for employee in employees:
+		validate_holiday_list_period_for_employee(employee, from_date, to_date)
+
+
+def validate_holiday_list_period_for_employee(employee: str, from_date: str, to_date: str):
+	"""Validate that all attendances for an employee are within the holiday list period."""
+	from_date = getdate(from_date)
+	to_date = getdate(to_date)
+
+	filters = {"employee": employee, "docstatus": 1}
+
+	if not frappe.db.exists("Attendance", filters):
+		return
+
+	min_attendance_date = frappe.db.get_all(
+		"Attendance", filters=filters, order_by="attendance_date asc", limit=1, pluck="attendance_date"
+	)[0]
+	max_attendance_date = frappe.db.get_all(
+		"Attendance", filters=filters, order_by="attendance_date desc", limit=1, pluck="attendance_date"
+	)[0]
+
+	if min_attendance_date <= from_date or max_attendance_date >= to_date:
+		msg = _("Employee {0} has Attendances outside the Holiday List period.").format(employee)
+		msg += "<br>" + _(
+			"Please adjust the Holiday List, such that it covers all Attendances (from {0} to {1} and possibly ongoing)."
+		).format(frappe.utils.format_date(min_attendance_date), frappe.utils.format_date(max_attendance_date))
+		frappe.throw(msg)


### PR DESCRIPTION
Solves following problem:
When someone works on a holiday, they earn the Working Hours such that they gain positive flexitime for that day.

Could break updating older **Attendances**, that are not covered by the period of the active **Holiday List**.

Todo:

- [x] Don't allow to reduce the period of the **Holiday List**, if 1) it is in an Employee, 2) the Employee has Attendances, that wont be covered anymore by the **Holiday List**'s period.