### PR TITLE
feat: set supervisor more robustly in Employee and fetch into Time Capture (DRC-270)

### DIFF
--- a/time_capture/custom_fields.py
+++ b/time_capture/custom_fields.py
@@ -36,6 +36,16 @@ def get_custom_fields():
 		],
 		"Employee": [
 			{
+				"fieldname": "custom_no_supervisor_required",
+				"fieldtype": "Check",
+				"label": _("No Supervisor Required"),
+				"insert_after": "reports_to",
+				"default": 0,
+				"description": _(
+					"Should be checked if the employee is a CEO (or has no supervisor for some reason)."
+				),
+			},
+			{
 				"fieldname": "expected_working_hours",
 				"fieldtype": "Table",
 				"insert_after": "attendance_device_id",

--- a/time_capture/patches.txt
+++ b/time_capture/patches.txt
@@ -3,8 +3,8 @@
 # Read docs to understand patches: https://frappeframework.com/docs/v14/user/en/database-migrations
 
 [post_model_sync]
-execute:from time_capture.install import _make_custom_fields;_make_custom_fields() # 2025-12-19 #2
-execute:from time_capture.install import _make_property_setters;_make_property_setters() # 2025-09-26
+execute:from time_capture.install import _make_custom_fields;_make_custom_fields() # 2026-01-22 #2
+execute:from time_capture.install import _make_property_setters;_make_property_setters() # 2026-01-22
 time_capture.patches.move_expected_working_time_to_child_table
 time_capture.patches.create_freelancer_role #7
 time_capture.patches.rectify_attendance_metrics

--- a/time_capture/patches.txt
+++ b/time_capture/patches.txt
@@ -4,7 +4,7 @@
 
 [post_model_sync]
 execute:from time_capture.install import _make_custom_fields;_make_custom_fields() # 2026-01-22 #2
-execute:from time_capture.install import _make_property_setters;_make_property_setters() # 2026-01-22
+execute:from time_capture.install import _make_property_setters;_make_property_setters() # 2026-01-22 #2
 time_capture.patches.move_expected_working_time_to_child_table
 time_capture.patches.create_freelancer_role #7
 time_capture.patches.rectify_attendance_metrics
@@ -12,3 +12,4 @@ time_capture.patches.delete_outdated_time_captures
 execute:frappe.db.set_value("Freelancer Time Capture", {"docstatus": ["!=", 0]}, {"check_in": "00:00", "check_out": "00:00"})
 execute:frappe.db.delete("Custom Field", {"name": "Employee-custom_update_attendances"})
 time_capture.patches.rectify_attendance_metrics_2512 # 2026-01-20 #3
+time_capture.patches.set_supervisor_in_employee_and_time_capture #4

--- a/time_capture/patches/set_supervisor_in_employee_and_time_capture.py
+++ b/time_capture/patches/set_supervisor_in_employee_and_time_capture.py
@@ -1,0 +1,44 @@
+import frappe
+
+
+def execute():
+	"""
+	Set Reports To in Employee and Time Capture.
+	"""
+	set_reports_to_in_employee()
+	set_reports_to_in_time_capture()
+
+
+def set_reports_to_in_employee():
+	"""
+	Set Reports To in Employee.
+	"""
+	employees = frappe.db.get_all("Employee", fields=["name", "leave_approver"])
+	for employee in employees:
+		doc = frappe.get_doc("Employee", employee.name)
+		if employee.leave_approver:
+			supervising_employee = frappe.db.get_all(
+				"Employee", filters={"user_id": employee.leave_approver}, pluck="name"
+			)
+			if supervising_employee:
+				doc.reports_to = supervising_employee[0]
+
+		if not doc.reports_to:
+			doc.custom_no_supervisor_required = 1
+
+		try:
+			doc.save()
+		except Exception as e:
+			print(f"Error setting Reports To for Employee {employee.name}: {e}")
+
+
+def set_reports_to_in_time_capture():
+	"""
+	Set Reports To in Time Capture.
+	"""
+	for employee in frappe.db.get_all(
+		"Employee", filters={"leave_approver": ["is", "set"]}, fields=["name", "leave_approver"]
+	):
+		frappe.db.set_value(
+			"Time Capture", {"employee": employee.name}, "supervisor_email", employee.leave_approver
+		)

--- a/time_capture/property_setters.py
+++ b/time_capture/property_setters.py
@@ -3,6 +3,13 @@ def get_property_setters():
 		("Attendance", "status", "allow_on_submit", "1"),
 		("Attendance", "working_hours", "allow_on_submit", "1"),
 		("Attendance", "working_hours", "precision", "2"),
+		("Employee", "reports_to", "mandatory_depends_on", "eval:!doc.custom_no_supervisor_required"),
+		("Employee", "expense_approver", "read_only", "1"),
+		("Employee", "expense_approver", "description", "Fetched from <i>Reports To</i> field."),
+		("Employee", "leave_approver", "read_only", "1"),
+		("Employee", "leave_approver", "description", "Fetched from <i>Reports To</i> field."),
+		("Employee", "shift_request_approver", "read_only", "1"),
+		("Employee", "shift_request_approver", "description", "Fetched from <i>Reports To</i> field."),
 		("Employee", "working_hours_per_week", "hidden", "1"),
 		("Employee", "holiday_list", "reqd", "1"),
 	]

--- a/time_capture/property_setters.py
+++ b/time_capture/property_setters.py
@@ -4,6 +4,7 @@ def get_property_setters():
 		("Attendance", "working_hours", "allow_on_submit", "1"),
 		("Attendance", "working_hours", "precision", "2"),
 		("Employee", "reports_to", "mandatory_depends_on", "eval:!doc.custom_no_supervisor_required"),
+		("Employee", "reports_to", "read_only_depends_on", "eval: doc.custom_no_supervisor_required"),
 		("Employee", "expense_approver", "read_only", "1"),
 		("Employee", "expense_approver", "description", "Fetched from <i>Reports To</i> field."),
 		("Employee", "leave_approver", "read_only", "1"),

--- a/time_capture/scripts/employee.py
+++ b/time_capture/scripts/employee.py
@@ -8,6 +8,10 @@ from hrms.hr.utils import get_leave_period
 from time_capture.scripts.holiday_list import validate_holiday_list_period_for_employee
 
 
+def before_validate(doc, method):
+	validate_expected_working_hours(doc)
+
+
 def validate(doc, method=None):
 	if doc.is_new():
 		create_leave_policy_assignment(doc)
@@ -22,10 +26,6 @@ def validate(doc, method=None):
 	if not doc.is_new() and doc.has_value_changed("holiday_list") and doc.holiday_list:
 		from_date, to_date = frappe.db.get_value("Holiday List", doc.holiday_list, ["from_date", "to_date"])
 		validate_holiday_list_period_for_employee(doc.name, from_date, to_date)
-
-
-def before_validate(doc, method):
-	validate_expected_working_hours(doc)
 
 
 def validate_expected_working_hours(doc):

--- a/time_capture/scripts/employee.py
+++ b/time_capture/scripts/employee.py
@@ -10,6 +10,7 @@ from time_capture.scripts.holiday_list import validate_holiday_list_period_for_e
 
 def before_validate(doc, method):
 	validate_expected_working_hours(doc)
+	set_supervisor_from_reports_to(doc)
 
 
 def validate(doc, method=None):
@@ -49,6 +50,52 @@ def validate_expected_working_hours(doc):
 					frappe.utils.format_date(ewh.valid_from)
 				)
 			)
+
+
+def set_supervisor_from_reports_to(doc):
+	"""
+	Set supervisor from reports_to field.
+	"""
+	supervisor = _validate_and_get_supervisor(doc)
+	if not supervisor:
+		return
+
+	doc.expense_approver = supervisor
+	doc.leave_approver = supervisor
+	doc.shift_request_approver = supervisor
+
+
+def _validate_and_get_supervisor(doc):
+	"""
+	- Supervisor is not the same as the employee.
+	- Reset Reports To for "CEOs"
+	- Supervisor has a User linked.
+	- Hint: "CEOs" have User Permission checkbox disabled.
+	"""
+	# Validate User Error
+	if doc.reports_to == doc.name:
+		frappe.throw(_("The supervisor cannot be the same as the employee."))
+
+	# Reset Reports To for "CEOs"
+	if doc.custom_no_supervisor_required:
+		doc.reports_to = None
+
+	# Handle no Reports To
+	if not doc.reports_to:
+		if doc.create_user_permission:
+			frappe.msgprint(
+				_(
+					"This Employee has no supervisor (<i>Reports To</i>), but has <i>Create User Permission</i> checkbox enabled. Please, make sure that this intended."
+				),
+				title=_("Possible mis-configuration?"),
+			)
+		return None
+
+	# Get Supervisor User
+	supervisor_user = frappe.db.get_value("Employee", doc.reports_to, "user_id")
+	if not supervisor_user:
+		frappe.throw(_("The supervisor has no User linked in his/her Employee record."))
+	return supervisor_user
 
 
 def create_leave_policy_assignment(doc):

--- a/time_capture/time_capture/doctype/time_capture/time_capture.json
+++ b/time_capture/time_capture/doctype/time_capture/time_capture.json
@@ -12,6 +12,7 @@
   "employee",
   "is_of_legal_age",
   "email",
+  "supervisor_email",
   "section_break_o1qi",
   "check_in",
   "column_break_ssa2",
@@ -174,6 +175,13 @@
    "print_hide": 1,
    "read_only": 1,
    "search_index": 1
+  },
+  {
+   "fieldname": "supervisor_email",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Supervisor Email",
+   "options": "Email"
   }
  ],
  "grid_page_length": 50,
@@ -189,7 +197,7 @@
    "link_fieldname": "custom_time_capture"
   }
  ],
- "modified": "2025-03-19 18:44:33.115924",
+ "modified": "2026-01-22 12:10:53.216014",
  "modified_by": "Administrator",
  "module": "Time Capture",
  "name": "Time Capture",
@@ -224,6 +232,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/time_capture/time_capture/doctype/time_capture/time_capture.py
+++ b/time_capture/time_capture/doctype/time_capture/time_capture.py
@@ -55,7 +55,7 @@ class TimeCapture(Document):
 		self.calculate_totals()
 		if self.has_value_changed("employee") or self.has_value_changed("date"):
 			self.is_of_legal_age = self._get_is_of_legal_age()
-		self.set_notification_email_address()
+		self.set_notification_email_addresses()
 
 	def validate(self):
 		validate_time_log_description(self)
@@ -94,12 +94,20 @@ class TimeCapture(Document):
 		self.working_time = total_duration - self.break_time
 		self.unallocated_time = self.working_time - sum(row.duration for row in self.time_logs)
 
-	def set_notification_email_address(self):
+	def set_notification_email_addresses(self):
+		"""
+		Set Employee's and supervisor's email addresses for notification.
+		"""
 		if not self.has_value_changed("employee"):
 			return
-		self.email = frappe.db.get_value("Employee", self.employee, "user_id") or frappe.db.get_single_value(
-			"Time Capture Settings", "standard_email_recipient"
+		user_id, supervisor_email = frappe.db.get_value(
+			"Employee", self.employee, ["user_id", "leave_approver"]
 		)
+		self.email = user_id or frappe.db.get_single_value(
+			"Time Capture Settings",
+			"standard_email_recipient",
+		)
+		self.supervisor_email = supervisor_email
 
 	def create_attendance(self):
 		"""


### PR DESCRIPTION
## Motivation 1: Improve handling in **Employee**
This PR simplifies the **Employee** in the sense that only one field (_Reports To_) is responsible for setting the supervisor.
This field relies on following (risky) assumptions:
- The supervisor (_Reports To_ field) has a _User ID_ linked in his/her **Employee** record.
- The supervisor (_Reports To_ field) is always the same as the _Leave Approver_, _Shift Request Approver_ and _Expense Approver_.

If one of these assumptions are not true, this PR causes trouble.
This risk is accepted with this PR, since the assumptions are rather true, than false. And on the other hand without this improvement the data is often inconsistent. Example: Sometimes the supervisor is set in _Reports To_, sometimes in _Leave Approver_ and so on.)
A solution that would fit both cases is planned.

## Motivation 2: Fetch supervisor into **Time Capture**
This is mainly for Notifcation purposes. These can be configured via **Notification** DocType. They are not configured or created with this app (as of now).


