### PR TITLE
fix(Leave Type): move compensatory off setting to a custom field

### DIFF
--- a/time_capture/custom_fields.py
+++ b/time_capture/custom_fields.py
@@ -88,6 +88,15 @@ def get_custom_fields():
 				"reqd": 1,
 			},
 		],
+		"Leave Type": [
+			{
+				"fieldname": "custom_compensatory_off",
+				"fieldtype": "Check",
+				"insert_after": "is_compensatory",
+				"label": _("Compensatory Off"),
+				"default": 0,
+			},
+		],
 		"Task": [
 			{
 				"fieldname": "custom_is_active",

--- a/time_capture/patches.txt
+++ b/time_capture/patches.txt
@@ -3,8 +3,8 @@
 # Read docs to understand patches: https://frappeframework.com/docs/v14/user/en/database-migrations
 
 [post_model_sync]
-execute:from time_capture.install import _make_custom_fields;_make_custom_fields() # 2026-02-03 #1
-execute:from time_capture.install import _make_property_setters;_make_property_setters() # 2026-01-22 #2
+execute:from time_capture.install import _make_custom_fields;_make_custom_fields() # 2026-02-03 #2
+execute:from time_capture.install import _make_property_setters;_make_property_setters() # 2026-02-03 #2
 time_capture.patches.move_expected_working_time_to_child_table
 time_capture.patches.create_freelancer_role #7
 time_capture.patches.rectify_attendance_metrics
@@ -13,3 +13,4 @@ execute:frappe.db.set_value("Freelancer Time Capture", {"docstatus": ["!=", 0]},
 execute:frappe.db.delete("Custom Field", {"name": "Employee-custom_update_attendances"})
 time_capture.patches.rectify_attendance_metrics_2512 # 2026-01-20 #3
 time_capture.patches.set_supervisor_in_employee_and_time_capture #4
+time_capture.patches.migrate_compensatory_to_custom_field # 2026-01-03

--- a/time_capture/patches/migrate_compensatory_to_custom_field.py
+++ b/time_capture/patches/migrate_compensatory_to_custom_field.py
@@ -1,0 +1,8 @@
+import frappe
+
+
+def execute():
+	"""Migrate is_compensatory to custom_compensatory_off, then clear is_compensatory."""
+	leave_types = frappe.get_all("Leave Type", filters={"is_compensatory": 1}, pluck="name")
+	for leave_type in leave_types:
+		frappe.db.set_value("Leave Type", leave_type, {"custom_compensatory_off": 1, "is_compensatory": 0})

--- a/time_capture/property_setters.py
+++ b/time_capture/property_setters.py
@@ -13,4 +13,5 @@ def get_property_setters():
 		("Employee", "shift_request_approver", "description", "Fetched from <i>Reports To</i> field."),
 		("Employee", "working_hours_per_week", "hidden", "1"),
 		("Employee", "holiday_list", "reqd", "1"),
+		("Leave Type", "is_compensatory", "hidden", "1"),
 	]

--- a/time_capture/scripts/attendance.py
+++ b/time_capture/scripts/attendance.py
@@ -121,7 +121,7 @@ def _get_expected_working_hours_for_leave_days(
 	if expected_working_hours_full_day == 0:
 		# This should never happen, but just to avoid division by zero.
 		return 0.0
-	if frappe.db.get_value("Leave Type", leave_type, "is_compensatory"):
+	if frappe.db.get_value("Leave Type", leave_type, "custom_compensatory_off"):
 		# No matter if a compensatory leave is full or half day the expected hours will be a full day.
 		return expected_working_hours_full_day
 	if is_half_day:


### PR DESCRIPTION
Motivation:
Compensatory Off is now set to 0 when inserting **Leave Allocation** via **Leave Policy Assignment**.
HRMS tries to force us into using **Compensatory Leave Request**, but we want to stick with **Leave Application** only.