### PR TITLE
fix(Employee): make approver setting more flexible

### DIFF
--- a/time_capture/locale/de.po
+++ b/time_capture/locale/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Time Capture VERSION\n"
 "Report-Msgid-Bugs-To: patrick@alyf.de\n"
-"POT-Creation-Date: 2026-02-03 12:10+0053\n"
+"POT-Creation-Date: 2026-08-07 10:06+0053\n"
 "PO-Revision-Date: 2025-02-03 12:10+0053\n"
 "Last-Translator: patrick@alyf.de\n"
 "Language-Team: patrick@alyf.de\n"
@@ -65,7 +65,7 @@ msgstr "Abwesenheitsplan {0} zum Freigeben"
 msgid "Additional Break"
 msgstr "Zusätzliche Pause"
 
-#: time_capture/time_capture/doctype/absence_plan/absence_plan.py:310
+#: time_capture/time_capture/doctype/absence_plan/absence_plan.py:309
 msgid "All Dates are in the future. Please cancel the Absence Plan instead."
 msgstr "Alle Daten liegen in der Zukunft. Bitte stornieren Sie stattdessen den Abwesenheitsplan."
 
@@ -79,10 +79,6 @@ msgstr "Freigabe"
 msgid "Approved"
 msgstr "Genehmigt"
 
-#: time_capture/time_capture/report/working_time/working_time.js:24
-msgid "April"
-msgstr "April"
-
 #: time_capture/public/js/employee.js:56
 msgid "At least one Expected Working Hours entry is required."
 msgstr "Mindestens ein Eintrag in Erwartete Arbeitsstunden ist Pflicht."
@@ -91,10 +87,6 @@ msgstr "Mindestens ein Eintrag in Erwartete Arbeitsstunden ist Pflicht."
 #: time_capture/time_capture/doctype/time_capture/time_capture.json
 msgid "Attendance"
 msgstr "Anwesenheit"
-
-#: time_capture/time_capture/report/working_time/working_time.js:28
-msgid "August"
-msgstr "August"
 
 #. Label of a Duration field in DocType 'Time Capture'
 #: time_capture/time_capture/doctype/time_capture/time_capture.json
@@ -107,7 +99,7 @@ msgstr "Pause"
 msgid "Bulk Insert"
 msgstr "Massen einfügen"
 
-#: time_capture/custom_fields.py:78 time_capture/public/js/employee.js:29
+#: time_capture/custom_fields.py:79 time_capture/public/js/employee.js:29
 msgid "Change/Add Expected Hours"
 msgstr "Erwartete Stunden ändern/hinzufügen"
 
@@ -131,6 +123,10 @@ msgstr "Auschecken"
 msgid "Choose a regular (from 1 to 28) for monthly notifications. If empty, the last day of the month will be used."
 msgstr "Wählen Sie einen regulären Tag (von 1 bis 28) für monatliche Benachrichtigungen. Wenn leer, wird der letzte Tag des Monats verwendet."
 
+#: time_capture/custom_fields.py:98
+msgid "Compensatory Off"
+msgstr ""
+
 #. Name of a DocType
 #. Label of a shortcut in the Freelancer Workspace
 #: time_capture/time_capture/doctype/create_freelancer/create_freelancer.json
@@ -146,7 +142,7 @@ msgstr "Freelancer-Benutzer erstellen"
 msgid "Creating Freelancer User"
 msgstr "Freelancer-Benutzer wird erstellt"
 
-#: time_capture/public/js/utils.js:189
+#: time_capture/public/js/utils.js:201
 #: time_capture/time_capture/report/leave_and_working_time_summaries/leave_and_working_time_summaries.py:75
 #: time_capture/time_capture/report/working_time_summary/working_time_summary.py:72
 msgid "Current Balance"
@@ -155,10 +151,6 @@ msgstr "Aktuelles Saldo"
 #: time_capture/time_capture/doctype/absence_plan/absence_plan.py:225
 msgid "Dates cannot be in the past or today."
 msgstr "Daten dürfen nicht in der Vergangenheit (oder auf heute) liegen."
-
-#: time_capture/time_capture/report/working_time/working_time.js:32
-msgid "December"
-msgstr "Dezember"
 
 #. Label of a Link field in DocType 'Time Capture Settings'
 #: time_capture/time_capture/doctype/time_capture_settings/time_capture_settings.json
@@ -174,7 +166,7 @@ msgstr "Standard-Freelancer-Aktivitätstyp"
 msgid "Delete Future Dates"
 msgstr "Zukünftige Daten löschen"
 
-#: time_capture/time_capture/doctype/absence_plan/absence_plan.py:312
+#: time_capture/time_capture/doctype/absence_plan/absence_plan.py:311
 msgid "Deleted {0} future date(s)."
 msgstr "{0} zukünftige Datum/Daten gelöscht."
 
@@ -261,21 +253,17 @@ msgstr "Die erwartete tägliche Arbeitszeit darf nicht geringer als 0h sein."
 
 #: time_capture/custom_fields.py:11 time_capture/custom_fields.py:70
 #: time_capture/public/js/employee.js:35
-#: time_capture/time_capture/report/working_time/working_time.py:30
 msgid "Expected Working Hours"
 msgstr "Erwartete Arbeitsstunden"
 
-#: time_capture/time_capture/report/working_time/working_time.js:22
-msgid "February"
-msgstr "Februar"
+#: time_capture/property_setters.py:12 time_capture/property_setters.py:15
+#: time_capture/property_setters.py:18
+msgid "Fetched from <i>Reports To</i> field, if empty."
+msgstr "Wird aus dem Feld <i>Vorgesetzter</i> übernommen, falls leer."
 
 #: time_capture/custom_fields.py:18
 msgid "Flexitime"
 msgstr "Gleitzeit"
-
-#: time_capture/time_capture/report/working_time/working_time.py:40
-msgid "Flexitime Change"
-msgstr "Gleitzeitänderung"
 
 #. Name of a DocType
 #: time_capture/time_capture/doctype/flexitime_correction/flexitime_correction.json
@@ -286,7 +274,6 @@ msgstr "Gleitzeitkorrektur"
 
 #. Label of a Float field in DocType 'Flexitime Correction'
 #: time_capture/time_capture/doctype/flexitime_correction/flexitime_correction.json
-#: time_capture/time_capture/report/working_time/working_time.py:45
 msgid "Flexitime Hours"
 msgstr "Gleitzeitstunden"
 
@@ -308,7 +295,7 @@ msgid "Freelancer Name"
 msgstr "Freelancer-Name"
 
 #. Name of a DocType
-#: time_capture/custom_fields.py:119
+#: time_capture/custom_fields.py:130
 #: time_capture/time_capture/doctype/freelancer_time_capture/freelancer_time_capture.json
 msgid "Freelancer Time Capture"
 msgstr "Freelancer Zeiterfassung"
@@ -317,11 +304,11 @@ msgstr "Freelancer Zeiterfassung"
 msgid "Freelancer Time Capture can only be created for users with the 'Freelancer' role. Change the user in the field 'User'."
 msgstr "Freelancer Zeiterfassung kann nur für Benutzer mit der 'Freelancer'-Rolle erstellt werden. Ändern Sie den Benutzer im Feld 'Benutzer'."
 
-#: time_capture/custom_fields.py:127
+#: time_capture/custom_fields.py:138
 msgid "Freelancer User"
 msgstr "Freelancer-Benutzer"
 
-#: time_capture/time_capture/doctype/absence_plan/absence_plan.py:285
+#: time_capture/time_capture/doctype/absence_plan/absence_plan.py:284
 msgid "From Date is in the future. This means you can just cancel the whole Absence Plan."
 msgstr "Das Von-Datum liegt in der Zukunft. Daher kann der komplette Abwesenheitsplan storniert werden."
 
@@ -329,7 +316,7 @@ msgstr "Das Von-Datum liegt in der Zukunft. Daher kann der komplette Abwesenheit
 msgid "Future Balance"
 msgstr "Zukünftiges Saldo"
 
-#: time_capture/public/js/utils.js:191
+#: time_capture/public/js/utils.js:221
 msgid "Future Balance (after planned reduction)"
 msgstr "Zukünftiges Saldo (nach geplanter Reduzierung)"
 
@@ -337,7 +324,7 @@ msgstr "Zukünftiges Saldo (nach geplanter Reduzierung)"
 msgid "Future Balance Changes"
 msgstr "Zukünftige Saldoänderungen"
 
-#: time_capture/public/js/utils.js:191
+#: time_capture/public/js/utils.js:214
 msgid "Future, approved overtime reductions."
 msgstr "Zukünftige, genehmigte Überstundenreduzierungen."
 
@@ -385,19 +372,7 @@ msgstr "Ungültiger Modus"
 msgid "Is Of Legal Age"
 msgstr "Ist volljährig"
 
-#: time_capture/time_capture/report/working_time/working_time.js:21
-msgid "January"
-msgstr "Januar"
-
-#: time_capture/time_capture/report/working_time/working_time.js:27
-msgid "July"
-msgstr "Juli"
-
-#: time_capture/time_capture/report/working_time/working_time.js:26
-msgid "June"
-msgstr "Juni"
-
-#: time_capture/public/js/utils.js:187
+#: time_capture/public/js/utils.js:190
 msgid "Last Manual Balance Correction"
 msgstr "Letzte manuelle Saldo-Korrektur"
 
@@ -412,7 +387,7 @@ msgstr "Letzte Benachrichtigung (gesendet am)"
 msgid "Leave Approver"
 msgstr "Urlaubsgenehmiger"
 
-#: time_capture/custom_fields.py:83
+#: time_capture/custom_fields.py:84
 msgid "Leave Policy"
 msgstr "Urlaubsrichtlinie"
 
@@ -420,12 +395,12 @@ msgstr "Urlaubsrichtlinie"
 msgid "Leave Policy has been changed. Note, that this will not update existing Leave Allocations or create/update future Leave Allocations."
 msgstr "Urlaubsrichtlinie wurde geändert. Hinweis: Dies aktualisiert keine bestehenden Urlaubszuweisungen oder erstellt/aktualisiert zukünftige Urlaubszuweisungen."
 
-#: time_capture/public/js/utils.js:113 time_capture/public/js/utils.js:143
+#: time_capture/public/js/utils.js:113 time_capture/public/js/utils.js:146
 msgid "Leave Summary"
 msgstr "Urlaubsübersicht"
 
 #. Label of a Link field in DocType 'Absence Plan'
-#: time_capture/public/js/utils.js:143
+#: time_capture/public/js/utils.js:151
 #: time_capture/time_capture/doctype/absence_plan/absence_plan.json
 msgid "Leave Type"
 msgstr "Urlaubstyp"
@@ -466,14 +441,6 @@ msgstr "Verpflichtende Pausen"
 msgid "Mandatory Breaks (Minors)"
 msgstr "Verpflichtende Pausen (Minderjährige)"
 
-#: time_capture/time_capture/report/working_time/working_time.js:23
-msgid "March"
-msgstr "März"
-
-#: time_capture/time_capture/report/working_time/working_time.js:25
-msgid "May"
-msgstr "Mai"
-
 #. Label of a Int field in DocType 'Time Capture Settings'
 #: time_capture/time_capture/doctype/time_capture_settings/time_capture_settings.json
 msgid "Minimum Draft Age (Days)"
@@ -495,7 +462,7 @@ msgstr "Kein Budget mehr für Aufgabe {0}. Bitte kontaktieren Sie den Projektman
 msgid "No employee found for current user"
 msgstr "Kein Mitarbeiter für aktuellen Benutzer gefunden"
 
-#: time_capture/public/js/utils.js:251
+#: time_capture/public/js/utils.js:253
 msgid "No working time data found"
 msgstr "Keine Arbeitszeitdaten gefunden"
 
@@ -503,7 +470,7 @@ msgstr "Keine Arbeitszeitdaten gefunden"
 msgid "Note must be at least 5 characters. Found: {0}"
 msgstr "Hinweis muss mindestens 5 Zeichen lang sein. Gefunden: {0}"
 
-#: time_capture/scripts/employee.py:134
+#: time_capture/scripts/employee.py:139
 msgid "Note: Following Leaves Types were created: {0}.<br>Following Leave Types were not created: {1}"
 msgstr "Hinweis: Die folgenden Abwesenheitsarten wurden erstellt: {0}.<br>Die folgenden Abwesenheitsarten wurden nicht erstellt: {1}"
 
@@ -535,14 +502,6 @@ msgstr "Benachrichtigungswochentag"
 msgid "Notification day of the month has to be between 1 and 28"
 msgstr "Der Benachrichtigungstag des Monats muss zwischen 1 und 28 liegen"
 
-#: time_capture/time_capture/report/working_time/working_time.js:31
-msgid "November"
-msgstr "November"
-
-#: time_capture/time_capture/report/working_time/working_time.js:30
-msgid "October"
-msgstr "Oktober"
-
 #: time_capture/time_capture/doctype/absence_plan/absence_plan.js:78
 msgid "Official weekly offs (e.g. 4 day work week set in employee contract) should be handled via Holiday List."
 msgstr "Offizielle wöchentliche freie Tage (z. B. 4-Tage-Woche im Arbeitsvertrag) sollten über die Feiertagsliste abgebildet werden."
@@ -565,7 +524,7 @@ msgstr "Nur Erinnerungen für Entwürfe senden, die älter sind als diese Anzahl
 msgid "Only submitted Absence Plans can use this action."
 msgstr "Nur gebuchte Abwesenheitspläne können diese Aktion ausführen."
 
-#: time_capture/time_capture/doctype/absence_plan/absence_plan.py:289
+#: time_capture/time_capture/doctype/absence_plan/absence_plan.py:287
 msgid "Only the Leave Approver and users with the 'Cancel' permission can delete future dates."
 msgstr "Nur der Urlaubsgenehmiger und Benutzer mit der Berechtigung „Stornieren“ können zukünftige Daten löschen."
 
@@ -573,11 +532,7 @@ msgstr "Nur der Urlaubsgenehmiger und Benutzer mit der Berechtigung „Storniere
 msgid "Open Time Captures"
 msgstr "Offene Zeiterfassungen"
 
-#: time_capture/time_capture/report/working_time/working_time.py:60
-msgid "Other Absence Days"
-msgstr "Andere Abwesenheitstage"
-
-#: time_capture/public/js/utils.js:191
+#: time_capture/public/js/utils.js:230
 msgid "Overdue Time Captures"
 msgstr "Überfällige Zeiterfassungen"
 
@@ -585,24 +540,15 @@ msgstr "Überfällige Zeiterfassungen"
 msgid "Overlapping Dates are not allowed"
 msgstr "Überlappende Daten sind nicht erlaubt"
 
-#: time_capture/time_capture/report/working_time/working_time.py:50
-msgid "Paid Holidays"
-msgstr "Bezahlte Feiertage"
-
-#. Label of a Link field in DocType 'Time Capture Settings'
-#: time_capture/time_capture/doctype/time_capture_settings/time_capture_settings.json
-msgid "Paid Leave Type"
-msgstr "Urlaubstyp Bezahlt"
-
-#: time_capture/public/js/utils.js:191
+#: time_capture/public/js/utils.js:232
 msgid "Past time captures, that are not yet submitted. These count as absent and reduce the balance."
 msgstr "Vergangene Zeiterfassungen, die noch nicht eingereicht wurden. Diese zählen als abwesend und reduzieren das Saldo."
 
-#: time_capture/time_capture/doctype/absence_plan/absence_plan.py:290
+#: time_capture/time_capture/doctype/absence_plan/absence_plan.py:288
 msgid "Permission Denied"
 msgstr "Berechtigung verweigert"
 
-#: time_capture/public/js/utils.js:191
+#: time_capture/public/js/utils.js:212
 msgid "Planned Overtime Reduction"
 msgstr "Geplante Überstundenreduzierung"
 
@@ -634,11 +580,6 @@ msgstr "Bitte füllen Sie alle Felder aus."
 msgid "Possible mis-configuration?"
 msgstr "Mögliche Fehlkonfiguration?"
 
-#. Name of a report
-#: time_capture/time_capture/report/project_time/project_time.json
-msgid "Project Time"
-msgstr "Projektzeit"
-
 #: time_capture/time_capture/doctype/time_capture/time_capture.py:80
 msgid "Project time cannot be greater than working time."
 msgstr "Die Projektzeit darf nicht größer sein als die Arbeitszeit."
@@ -655,17 +596,9 @@ msgstr "Zeile {0}: Dauer ist nicht im korrekten Format."
 msgid "Save & Update Attendances"
 msgstr "Speichern & Anwesenheiten aktualisieren"
 
-#: time_capture/time_capture/report/working_time/working_time.js:29
-msgid "September"
-msgstr "September"
-
 #: time_capture/custom_fields.py:62
 msgid "Should be checked if the employee is a CEO (or has no supervisor for some reason)."
 msgstr "Sollte aktiviert sein, wenn der Mitarbeiter ein Geschäftsführer ist (oder aus anderem Grund keinen Vorgesetzten hat)."
-
-#: time_capture/time_capture/report/working_time/working_time.py:55
-msgid "Sick Days"
-msgstr "Krankheitstage"
 
 #. Label of a Link field in DocType 'Time Capture Settings'
 #: time_capture/time_capture/doctype/time_capture_settings/time_capture_settings.json
@@ -682,10 +615,6 @@ msgstr "Standard-E-Mail-Empfänger"
 msgid "Submit Timesheets immediately"
 msgstr "Stundenzettel sofort buchen"
 
-#: time_capture/time_capture/report/project_time/project_time.py:125
-msgid "Sum for {}"
-msgstr "Summe für {}"
-
 #. Label of a Data field in DocType 'Time Capture'
 #: time_capture/time_capture/doctype/time_capture/time_capture.json
 msgid "Supervisor Email"
@@ -699,7 +628,7 @@ msgstr "Vorgang {0} gehört nicht zu Projekt {1}"
 msgid "The date of joining ({0}) has to be the earliest date of Expected Working Hours."
 msgstr "Das Beitrittsdatum muss dem frühesten Datum in Erwartete Arbeitsstunden entsprechen."
 
-#: time_capture/scripts/employee.py:153
+#: time_capture/scripts/employee.py:158
 msgid "The date {0} is not within the period of the active holiday list for employee {1}."
 msgstr "Das Datum {0} liegt nicht innerhalb der Periode der Feiertagsliste des Mitarbeiters {1}."
 
@@ -727,20 +656,20 @@ msgstr "Es gibt überlappende Daten mit folgenden Abwesenheitsplänen:<br>{0}"
 msgid "This Employee has no supervisor (<i>Reports To</i>), but has <i>Create User Permission</i> checkbox enabled. Please, make sure that this intended."
 msgstr "Dieser Mitarbeiter hat keinen <i>Vorgesetzten</i>, aber er hat <i>Benutzerberechtigung Erstellen</i> aktiviert. Bitte prüfen Sie, ob das gewollt ist."
 
-#: time_capture/public/js/utils.js:187
+#: time_capture/public/js/utils.js:192
 msgid "This could be (for example) a starting balance you took on from your previous time capture system."
 msgstr "Dies könnte (zum Beispiel) ein Start-Saldo sein, das Sie von Ihrem vorherigen Zeiterfassungssystem übernommen haben."
 
-#: time_capture/public/js/utils.js:189
+#: time_capture/public/js/utils.js:203
 msgid "This includes the last manual balance correction (if existing) and the sum of your working hours (minus your expected working hours)."
 msgstr "Dies umfasst die letzte manuelle Saldo-Korrektur (falls vorhanden) und die Summe Ihrer Arbeitsstunden (abzüglich Ihrer erwarteten Arbeitsstunden)."
 
-#: time_capture/public/js/utils.js:191
+#: time_capture/public/js/utils.js:223
 msgid "This is the projected balance, that includes planned overtime reductions"
 msgstr "Dies ist das prognostizierte Saldo, das geplante Überstundenreduzierungen enthält"
 
 #. Name of a DocType
-#: time_capture/custom_fields.py:46 time_capture/custom_fields.py:111
+#: time_capture/custom_fields.py:46 time_capture/custom_fields.py:122
 #: time_capture/time_capture/doctype/time_capture/time_capture.json
 msgid "Time Capture"
 msgstr "Zeiterfassung"
@@ -817,9 +746,7 @@ msgid "Weekly Off: adds all dates in the range that fall on the selected weekday
 msgstr "Wöchentlicher freier Tag: fügt alle Daten im Bereich hinzu, die auf den gewählten Wochentag fallen. Die Feiertagsliste legt bereits arbeitsfreie Tage fest; z. B. jeden Sonntag als wöchentlichen freien Tag hinzuzufügen ist oft überflüssig."
 
 #. Label of a Duration field in DocType 'Time Capture'
-#. Name of a report
 #: time_capture/time_capture/doctype/time_capture/time_capture.json
-#: time_capture/time_capture/report/working_time/working_time.json
 msgid "Working Time"
 msgstr "Arbeitszeit"
 
@@ -829,7 +756,7 @@ msgid "Working Time (Greater Than)"
 msgstr "Arbeitszeit (Größer als)"
 
 #. Name of a report
-#: time_capture/public/js/utils.js:173
+#: time_capture/public/js/utils.js:181
 #: time_capture/time_capture/report/working_time_summary/working_time_summary.json
 msgid "Working Time Summary"
 msgstr "Arbeitszeitübersicht"
@@ -846,7 +773,7 @@ msgstr "Ihr Abwesenheitsplan {0} wurde {1}"
 msgid "{0} (on {1})"
 msgstr "{0} (am {1})"
 
-#: time_capture/scripts/employee.py:236
+#: time_capture/scripts/employee.py:241
 msgid "{0} Attendances updated successfully."
 msgstr "{0} Attendances erfolgreich aktualisiert."
 

--- a/time_capture/locale/main.pot
+++ b/time_capture/locale/main.pot
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Time Capture VERSION\n"
 "Report-Msgid-Bugs-To: patrick@alyf.de\n"
-"POT-Creation-Date: 2026-02-03 12:10+0053\n"
-"PO-Revision-Date: 2025-02-03 12:10+0053\n"
+"POT-Creation-Date: 2026-08-07 10:06+0053\n"
+"PO-Revision-Date: 2026-08-07 10:06+0053\n"
 "Last-Translator: patrick@alyf.de\n"
 "Language-Team: patrick@alyf.de\n"
 "MIME-Version: 1.0\n"
@@ -65,7 +65,7 @@ msgstr ""
 msgid "Additional Break"
 msgstr ""
 
-#: time_capture/time_capture/doctype/absence_plan/absence_plan.py:310
+#: time_capture/time_capture/doctype/absence_plan/absence_plan.py:309
 msgid "All Dates are in the future. Please cancel the Absence Plan instead."
 msgstr ""
 
@@ -79,10 +79,6 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: time_capture/time_capture/report/working_time/working_time.js:24
-msgid "April"
-msgstr ""
-
 #: time_capture/public/js/employee.js:56
 msgid "At least one Expected Working Hours entry is required."
 msgstr ""
@@ -90,10 +86,6 @@ msgstr ""
 #. Linked DocType in Time Capture's connections
 #: time_capture/time_capture/doctype/time_capture/time_capture.json
 msgid "Attendance"
-msgstr ""
-
-#: time_capture/time_capture/report/working_time/working_time.js:28
-msgid "August"
 msgstr ""
 
 #. Label of a Duration field in DocType 'Time Capture'
@@ -107,7 +99,7 @@ msgstr ""
 msgid "Bulk Insert"
 msgstr ""
 
-#: time_capture/custom_fields.py:78 time_capture/public/js/employee.js:29
+#: time_capture/custom_fields.py:79 time_capture/public/js/employee.js:29
 msgid "Change/Add Expected Hours"
 msgstr ""
 
@@ -131,6 +123,10 @@ msgstr ""
 msgid "Choose a regular (from 1 to 28) for monthly notifications. If empty, the last day of the month will be used."
 msgstr ""
 
+#: time_capture/custom_fields.py:98
+msgid "Compensatory Off"
+msgstr ""
+
 #. Name of a DocType
 #. Label of a shortcut in the Freelancer Workspace
 #: time_capture/time_capture/doctype/create_freelancer/create_freelancer.json
@@ -146,7 +142,7 @@ msgstr ""
 msgid "Creating Freelancer User"
 msgstr ""
 
-#: time_capture/public/js/utils.js:189
+#: time_capture/public/js/utils.js:201
 #: time_capture/time_capture/report/leave_and_working_time_summaries/leave_and_working_time_summaries.py:75
 #: time_capture/time_capture/report/working_time_summary/working_time_summary.py:72
 msgid "Current Balance"
@@ -154,10 +150,6 @@ msgstr ""
 
 #: time_capture/time_capture/doctype/absence_plan/absence_plan.py:225
 msgid "Dates cannot be in the past or today."
-msgstr ""
-
-#: time_capture/time_capture/report/working_time/working_time.js:32
-msgid "December"
 msgstr ""
 
 #. Label of a Link field in DocType 'Time Capture Settings'
@@ -174,7 +166,7 @@ msgstr ""
 msgid "Delete Future Dates"
 msgstr ""
 
-#: time_capture/time_capture/doctype/absence_plan/absence_plan.py:312
+#: time_capture/time_capture/doctype/absence_plan/absence_plan.py:311
 msgid "Deleted {0} future date(s)."
 msgstr ""
 
@@ -261,20 +253,16 @@ msgstr ""
 
 #: time_capture/custom_fields.py:11 time_capture/custom_fields.py:70
 #: time_capture/public/js/employee.js:35
-#: time_capture/time_capture/report/working_time/working_time.py:30
 msgid "Expected Working Hours"
 msgstr ""
 
-#: time_capture/time_capture/report/working_time/working_time.js:22
-msgid "February"
+#: time_capture/property_setters.py:12 time_capture/property_setters.py:15
+#: time_capture/property_setters.py:18
+msgid "Fetched from <i>Reports To</i> field, if empty."
 msgstr ""
 
 #: time_capture/custom_fields.py:18
 msgid "Flexitime"
-msgstr ""
-
-#: time_capture/time_capture/report/working_time/working_time.py:40
-msgid "Flexitime Change"
 msgstr ""
 
 #. Name of a DocType
@@ -286,7 +274,6 @@ msgstr ""
 
 #. Label of a Float field in DocType 'Flexitime Correction'
 #: time_capture/time_capture/doctype/flexitime_correction/flexitime_correction.json
-#: time_capture/time_capture/report/working_time/working_time.py:45
 msgid "Flexitime Hours"
 msgstr ""
 
@@ -308,7 +295,7 @@ msgid "Freelancer Name"
 msgstr ""
 
 #. Name of a DocType
-#: time_capture/custom_fields.py:119
+#: time_capture/custom_fields.py:130
 #: time_capture/time_capture/doctype/freelancer_time_capture/freelancer_time_capture.json
 msgid "Freelancer Time Capture"
 msgstr ""
@@ -317,11 +304,11 @@ msgstr ""
 msgid "Freelancer Time Capture can only be created for users with the 'Freelancer' role. Change the user in the field 'User'."
 msgstr ""
 
-#: time_capture/custom_fields.py:127
+#: time_capture/custom_fields.py:138
 msgid "Freelancer User"
 msgstr ""
 
-#: time_capture/time_capture/doctype/absence_plan/absence_plan.py:285
+#: time_capture/time_capture/doctype/absence_plan/absence_plan.py:284
 msgid "From Date is in the future. This means you can just cancel the whole Absence Plan."
 msgstr ""
 
@@ -329,7 +316,7 @@ msgstr ""
 msgid "Future Balance"
 msgstr ""
 
-#: time_capture/public/js/utils.js:191
+#: time_capture/public/js/utils.js:221
 msgid "Future Balance (after planned reduction)"
 msgstr ""
 
@@ -337,7 +324,7 @@ msgstr ""
 msgid "Future Balance Changes"
 msgstr ""
 
-#: time_capture/public/js/utils.js:191
+#: time_capture/public/js/utils.js:214
 msgid "Future, approved overtime reductions."
 msgstr ""
 
@@ -385,19 +372,7 @@ msgstr ""
 msgid "Is Of Legal Age"
 msgstr ""
 
-#: time_capture/time_capture/report/working_time/working_time.js:21
-msgid "January"
-msgstr ""
-
-#: time_capture/time_capture/report/working_time/working_time.js:27
-msgid "July"
-msgstr ""
-
-#: time_capture/time_capture/report/working_time/working_time.js:26
-msgid "June"
-msgstr ""
-
-#: time_capture/public/js/utils.js:187
+#: time_capture/public/js/utils.js:190
 msgid "Last Manual Balance Correction"
 msgstr ""
 
@@ -412,7 +387,7 @@ msgstr ""
 msgid "Leave Approver"
 msgstr ""
 
-#: time_capture/custom_fields.py:83
+#: time_capture/custom_fields.py:84
 msgid "Leave Policy"
 msgstr ""
 
@@ -420,12 +395,12 @@ msgstr ""
 msgid "Leave Policy has been changed. Note, that this will not update existing Leave Allocations or create/update future Leave Allocations."
 msgstr ""
 
-#: time_capture/public/js/utils.js:113 time_capture/public/js/utils.js:143
+#: time_capture/public/js/utils.js:113 time_capture/public/js/utils.js:146
 msgid "Leave Summary"
 msgstr ""
 
 #. Label of a Link field in DocType 'Absence Plan'
-#: time_capture/public/js/utils.js:143
+#: time_capture/public/js/utils.js:151
 #: time_capture/time_capture/doctype/absence_plan/absence_plan.json
 msgid "Leave Type"
 msgstr ""
@@ -466,14 +441,6 @@ msgstr ""
 msgid "Mandatory Breaks (Minors)"
 msgstr ""
 
-#: time_capture/time_capture/report/working_time/working_time.js:23
-msgid "March"
-msgstr ""
-
-#: time_capture/time_capture/report/working_time/working_time.js:25
-msgid "May"
-msgstr ""
-
 #. Label of a Int field in DocType 'Time Capture Settings'
 #: time_capture/time_capture/doctype/time_capture_settings/time_capture_settings.json
 msgid "Minimum Draft Age (Days)"
@@ -495,7 +462,7 @@ msgstr ""
 msgid "No employee found for current user"
 msgstr ""
 
-#: time_capture/public/js/utils.js:251
+#: time_capture/public/js/utils.js:253
 msgid "No working time data found"
 msgstr ""
 
@@ -503,7 +470,7 @@ msgstr ""
 msgid "Note must be at least 5 characters. Found: {0}"
 msgstr ""
 
-#: time_capture/scripts/employee.py:134
+#: time_capture/scripts/employee.py:139
 msgid "Note: Following Leaves Types were created: {0}.<br>Following Leave Types were not created: {1}"
 msgstr ""
 
@@ -535,14 +502,6 @@ msgstr ""
 msgid "Notification day of the month has to be between 1 and 28"
 msgstr ""
 
-#: time_capture/time_capture/report/working_time/working_time.js:31
-msgid "November"
-msgstr ""
-
-#: time_capture/time_capture/report/working_time/working_time.js:30
-msgid "October"
-msgstr ""
-
 #: time_capture/time_capture/doctype/absence_plan/absence_plan.js:78
 msgid "Official weekly offs (e.g. 4 day work week set in employee contract) should be handled via Holiday List."
 msgstr ""
@@ -565,7 +524,7 @@ msgstr ""
 msgid "Only submitted Absence Plans can use this action."
 msgstr ""
 
-#: time_capture/time_capture/doctype/absence_plan/absence_plan.py:289
+#: time_capture/time_capture/doctype/absence_plan/absence_plan.py:287
 msgid "Only the Leave Approver and users with the 'Cancel' permission can delete future dates."
 msgstr ""
 
@@ -573,11 +532,7 @@ msgstr ""
 msgid "Open Time Captures"
 msgstr ""
 
-#: time_capture/time_capture/report/working_time/working_time.py:60
-msgid "Other Absence Days"
-msgstr ""
-
-#: time_capture/public/js/utils.js:191
+#: time_capture/public/js/utils.js:230
 msgid "Overdue Time Captures"
 msgstr ""
 
@@ -585,24 +540,15 @@ msgstr ""
 msgid "Overlapping Dates are not allowed"
 msgstr ""
 
-#: time_capture/time_capture/report/working_time/working_time.py:50
-msgid "Paid Holidays"
-msgstr ""
-
-#. Label of a Link field in DocType 'Time Capture Settings'
-#: time_capture/time_capture/doctype/time_capture_settings/time_capture_settings.json
-msgid "Paid Leave Type"
-msgstr ""
-
-#: time_capture/public/js/utils.js:191
+#: time_capture/public/js/utils.js:232
 msgid "Past time captures, that are not yet submitted. These count as absent and reduce the balance."
 msgstr ""
 
-#: time_capture/time_capture/doctype/absence_plan/absence_plan.py:290
+#: time_capture/time_capture/doctype/absence_plan/absence_plan.py:288
 msgid "Permission Denied"
 msgstr ""
 
-#: time_capture/public/js/utils.js:191
+#: time_capture/public/js/utils.js:212
 msgid "Planned Overtime Reduction"
 msgstr ""
 
@@ -634,11 +580,6 @@ msgstr ""
 msgid "Possible mis-configuration?"
 msgstr ""
 
-#. Name of a report
-#: time_capture/time_capture/report/project_time/project_time.json
-msgid "Project Time"
-msgstr ""
-
 #: time_capture/time_capture/doctype/time_capture/time_capture.py:80
 msgid "Project time cannot be greater than working time."
 msgstr ""
@@ -655,16 +596,8 @@ msgstr ""
 msgid "Save & Update Attendances"
 msgstr ""
 
-#: time_capture/time_capture/report/working_time/working_time.js:29
-msgid "September"
-msgstr ""
-
 #: time_capture/custom_fields.py:62
 msgid "Should be checked if the employee is a CEO (or has no supervisor for some reason)."
-msgstr ""
-
-#: time_capture/time_capture/report/working_time/working_time.py:55
-msgid "Sick Days"
 msgstr ""
 
 #. Label of a Link field in DocType 'Time Capture Settings'
@@ -682,10 +615,6 @@ msgstr ""
 msgid "Submit Timesheets immediately"
 msgstr ""
 
-#: time_capture/time_capture/report/project_time/project_time.py:125
-msgid "Sum for {}"
-msgstr ""
-
 #. Label of a Data field in DocType 'Time Capture'
 #: time_capture/time_capture/doctype/time_capture/time_capture.json
 msgid "Supervisor Email"
@@ -699,7 +628,7 @@ msgstr ""
 msgid "The date of joining ({0}) has to be the earliest date of Expected Working Hours."
 msgstr ""
 
-#: time_capture/scripts/employee.py:153
+#: time_capture/scripts/employee.py:158
 msgid "The date {0} is not within the period of the active holiday list for employee {1}."
 msgstr ""
 
@@ -727,20 +656,20 @@ msgstr ""
 msgid "This Employee has no supervisor (<i>Reports To</i>), but has <i>Create User Permission</i> checkbox enabled. Please, make sure that this intended."
 msgstr ""
 
-#: time_capture/public/js/utils.js:187
+#: time_capture/public/js/utils.js:192
 msgid "This could be (for example) a starting balance you took on from your previous time capture system."
 msgstr ""
 
-#: time_capture/public/js/utils.js:189
+#: time_capture/public/js/utils.js:203
 msgid "This includes the last manual balance correction (if existing) and the sum of your working hours (minus your expected working hours)."
 msgstr ""
 
-#: time_capture/public/js/utils.js:191
+#: time_capture/public/js/utils.js:223
 msgid "This is the projected balance, that includes planned overtime reductions"
 msgstr ""
 
 #. Name of a DocType
-#: time_capture/custom_fields.py:46 time_capture/custom_fields.py:111
+#: time_capture/custom_fields.py:46 time_capture/custom_fields.py:122
 #: time_capture/time_capture/doctype/time_capture/time_capture.json
 msgid "Time Capture"
 msgstr ""
@@ -817,9 +746,7 @@ msgid "Weekly Off: adds all dates in the range that fall on the selected weekday
 msgstr ""
 
 #. Label of a Duration field in DocType 'Time Capture'
-#. Name of a report
 #: time_capture/time_capture/doctype/time_capture/time_capture.json
-#: time_capture/time_capture/report/working_time/working_time.json
 msgid "Working Time"
 msgstr ""
 
@@ -829,7 +756,7 @@ msgid "Working Time (Greater Than)"
 msgstr ""
 
 #. Name of a report
-#: time_capture/public/js/utils.js:173
+#: time_capture/public/js/utils.js:181
 #: time_capture/time_capture/report/working_time_summary/working_time_summary.json
 msgid "Working Time Summary"
 msgstr ""
@@ -846,7 +773,7 @@ msgstr ""
 msgid "{0} (on {1})"
 msgstr ""
 
-#: time_capture/scripts/employee.py:236
+#: time_capture/scripts/employee.py:241
 msgid "{0} Attendances updated successfully."
 msgstr ""
 

--- a/time_capture/property_setters.py
+++ b/time_capture/property_setters.py
@@ -1,3 +1,6 @@
+from .utils import identity as _
+
+
 def get_property_setters():
 	return [
 		("Attendance", "status", "allow_on_submit", "1"),
@@ -5,12 +8,20 @@ def get_property_setters():
 		("Attendance", "working_hours", "precision", "2"),
 		("Employee", "reports_to", "mandatory_depends_on", "eval:!doc.custom_no_supervisor_required"),
 		("Employee", "reports_to", "read_only_depends_on", "eval: doc.custom_no_supervisor_required"),
-		("Employee", "expense_approver", "read_only", "1"),
-		("Employee", "expense_approver", "description", "Fetched from <i>Reports To</i> field."),
-		("Employee", "leave_approver", "read_only", "1"),
-		("Employee", "leave_approver", "description", "Fetched from <i>Reports To</i> field."),
-		("Employee", "shift_request_approver", "read_only", "1"),
-		("Employee", "shift_request_approver", "description", "Fetched from <i>Reports To</i> field."),
+		("Employee", "expense_approver", "read_only", "0"),
+		("Employee", "expense_approver", "description", _("Fetched from <i>Reports To</i> field, if empty.")),
+		("Employee", "leave_approver", "read_only", "0"),
+		("Employee", "expense_approver", "no_copy", "1"),
+		("Employee", "leave_approver", "description", _("Fetched from <i>Reports To</i> field, if empty.")),
+		("Employee", "leave_approver", "no_copy", "1"),
+		("Employee", "shift_request_approver", "read_only", "0"),
+		(
+			"Employee",
+			"shift_request_approver",
+			"description",
+			_("Fetched from <i>Reports To</i> field, if empty."),
+		),
+		("Employee", "shift_request_approver", "no_copy", "1"),
 		("Employee", "working_hours_per_week", "hidden", "1"),
 		("Employee", "holiday_list", "reqd", "0"),
 		("Employee", "holiday_list", "mandatory_depends_on", "eval:doc.status == 'Active'"),

--- a/time_capture/scripts/employee.py
+++ b/time_capture/scripts/employee.py
@@ -60,9 +60,9 @@ def set_supervisor_from_reports_to(doc):
 	if not supervisor:
 		return
 
-	doc.expense_approver = supervisor
-	doc.leave_approver = supervisor
-	doc.shift_request_approver = supervisor
+	doc.expense_approver = doc.expense_approver or supervisor
+	doc.leave_approver = doc.leave_approver or supervisor
+	doc.shift_request_approver = doc.shift_request_approver or supervisor
 
 
 def _validate_and_get_supervisor(doc):


### PR DESCRIPTION
Fix:
Don't always set the approver fields based on `reports_to`. Only set if empty. This way, we avoid empty approvers and set some sort of default.

But:
We allow users to change the approvers to someone else.